### PR TITLE
Fix pre-screening DOI false positives; consume upgraded bibtex-check output contract

### DIFF
--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -8,6 +8,23 @@ Install: pipx install bibtex-updater  (or uv tool install bibtex-updater)
 NOTE: bibtex-updater requires bibtexparser 1.x which conflicts with
 hallmark's bibtexparser>=2.0.  It must be installed in an isolated
 environment (pipx / uv tool) and invoked as a CLI subprocess.
+
+Newer bibtex-check releases (post-1.2.0) extend the JSONL output contract;
+all extensions are presence-detected so older-format records parse exactly
+as before (the precomputed reference results are unaffected):
+
+- New problem statuses: ``nonexistent_venue`` (claimed venue unknown to the
+  DBLP/OpenAlex venue registries while >=2 sources return the paper with
+  other venues) and ``unpublished_at_claimed_venue`` (OpenReview: real paper,
+  not accepted at the cited venue; env-gated upstream, off by default).
+  ``author_truncated`` is now reachable in default mode (was --strict-only).
+- ``coverage_incomplete`` (bool): the verdict is an abstention/API_ERROR
+  reached while sources errored or were throttled.  A ``not_found`` carrying
+  this flag is NOT a clean exhaustive miss — the wrapper treats it as an
+  abstention (conservative VALID), not as evidence of fabrication.
+- ``p_valid`` (float in [0, 1]): explicit P(entry as cited is genuine) — the
+  value to threshold on.  When present it replaces the older realness
+  inversion heuristic for deriving ``Prediction.confidence``.
 """
 
 from __future__ import annotations
@@ -34,6 +51,7 @@ STATUS_TO_LABEL: dict[str, str] = {
     "author_mismatch": "HALLUCINATED",
     "year_mismatch": "HALLUCINATED",  # Year differs from database record
     "venue_mismatch": "HALLUCINATED",  # Venue differs from database record
+    "nonexistent_venue": "HALLUCINATED",  # Claimed venue unknown to DBLP/OpenAlex venue registries
     "partial_match": "HALLUCINATED",
     "hallucinated": "HALLUCINATED",
     "api_error": "VALID",  # Conservative: don't flag on errors
@@ -52,6 +70,7 @@ STATUS_TO_LABEL: dict[str, str] = {
     "doi_not_found": "HALLUCINATED",  # DOI returns HTTP 404
     # Preprint detection
     "preprint_only": "HALLUCINATED",  # Paper only exists as preprint, not at claimed venue
+    "unpublished_at_claimed_venue": "HALLUCINATED",  # OpenReview: real but not accepted at venue
     "published_version_exists": "VALID",  # Informational: published version found
     # Web reference verification
     "url_verified": "VALID",
@@ -76,6 +95,7 @@ STATUS_TO_CONFIDENCE: dict[str, float] = {
     "author_mismatch": 0.75,
     "year_mismatch": 0.75,
     "venue_mismatch": 0.80,
+    "nonexistent_venue": 0.85,
     "partial_match": 0.70,
     "hallucinated": 0.90,
     "api_error": 0.30,
@@ -91,6 +111,7 @@ STATUS_TO_CONFIDENCE: dict[str, float] = {
     "invalid_year": 0.70,
     "doi_not_found": 0.85,
     "preprint_only": 0.80,
+    "unpublished_at_claimed_venue": 0.75,
     "published_version_exists": 0.60,
     "url_verified": 0.90,
     "url_accessible": 0.70,
@@ -161,14 +182,22 @@ def run_bibtex_check_with_status(
     Values are the raw ``status`` field from the bibtex-check JSONL output, e.g.:
 
     - ``"verified"`` — found in at least one academic database and metadata matches
-    - ``"not_found"`` — no database returned a matching record
+    - ``"not_found"`` — no database returned a matching record.  The same status
+      string also covers coverage-incomplete lookups (post-1.2.0
+      ``coverage_incomplete`` records, where sources errored / were throttled);
+      the prediction for those is an abstention-style VALID, and downstream
+      cascades should keep routing ``"not_found"`` as uncertain.
     - ``"title_mismatch"`` / ``"author_mismatch"`` / ``"year_mismatch"`` /
       ``"venue_mismatch"`` — found but a field differs from the claimed value
+    - ``"nonexistent_venue"`` — claimed venue unknown to the DBLP/OpenAlex venue
+      registries while the paper itself is real (positive problem evidence)
     - ``"partial_match"`` — some fields match, others do not
     - ``"api_error"`` — transient API failure; treated conservatively as VALID
     - ``"future_date"`` / ``"invalid_year"`` — pre-API year validation failed
     - ``"doi_not_found"`` — DOI returned HTTP 404
     - ``"preprint_only"`` — paper exists only as a preprint, not at the claimed venue
+    - ``"unpublished_at_claimed_venue"`` — OpenReview: real paper, not accepted at
+      the cited venue (env-gated upstream, off by default)
     - ``"published_version_exists"`` — informational; published version was found
     - ``"url_verified"`` / ``"url_accessible"`` / ``"url_not_found"`` /
       ``"url_content_mismatch"`` — web-reference results (academic_only=False only)
@@ -406,20 +435,49 @@ def _parse_jsonl_output(
 
             label = STATUS_TO_LABEL.get(status, "VALID")
 
-            # bibtex-updater >=1.2.0 emits ``confidence`` as P(entry is real/valid)
-            # (verified ~0.67, mismatch ~0.0, unconfirmed ~0.22) plus a new
-            # ``confidence_score`` field. HALLMARK's Prediction.confidence is
-            # confidence-in-the-assigned-label, so convert: VALID keeps P(real);
-            # HALLUCINATED gets 1 - P(real). We detect the 1.2.0 realness
-            # semantics by the presence of the new fields so 0.10.0 output
-            # (which already encoded label-confidence) is left unchanged.
-            is_v12_realness = "confidence_score" in record or "abstained" in record
-            if is_v12_realness and label == "HALLUCINATED":
-                confidence = 1.0 - raw_confidence
+            # Post-1.2.0 records carry ``coverage_incomplete``: the abstention
+            # was reached while sources errored / were throttled, so a
+            # ``not_found`` with this flag is NOT a clean exhaustive miss.
+            # Treat it as an abstention (conservative VALID), not as evidence
+            # of fabrication. For all other statuses the flag is informational
+            # and the label mapping is unchanged.
+            incomplete_not_found = (
+                status == "not_found" and record.get("coverage_incomplete") is True
+            )
+            if incomplete_not_found:
+                label = "VALID"
+
+            p_valid = record.get("p_valid")
+            if incomplete_not_found:
+                confidence = 0.45
+            elif p_valid is not None:
+                # Post-1.2.0 records emit an explicit ``p_valid`` = P(entry as
+                # cited is genuine) — the documented value to threshold on.
+                # HALLMARK's Prediction.confidence is confidence in the
+                # assigned label, so VALID keeps p_valid and HALLUCINATED gets
+                # 1 - p_valid. Its presence implies the new format, so this
+                # replaces the 1.2.0 realness inversion heuristic below.
+                confidence = float(p_valid) if label == "VALID" else 1.0 - float(p_valid)
             else:
-                confidence = raw_confidence
+                # bibtex-updater >=1.2.0 emits ``confidence`` as P(entry is real/valid)
+                # (verified ~0.67, mismatch ~0.0, unconfirmed ~0.22) plus a new
+                # ``confidence_score`` field. HALLMARK's Prediction.confidence is
+                # confidence-in-the-assigned-label, so convert: VALID keeps P(real);
+                # HALLUCINATED gets 1 - P(real). We detect the 1.2.0 realness
+                # semantics by the presence of the new fields so 0.10.0 output
+                # (which already encoded label-confidence) is left unchanged.
+                is_v12_realness = "confidence_score" in record or "abstained" in record
+                if is_v12_realness and label == "HALLUCINATED":
+                    confidence = 1.0 - raw_confidence
+                else:
+                    confidence = raw_confidence
 
             reason_parts = [f"Status: {status}"]
+            if incomplete_not_found:
+                reason_parts.append(
+                    "Lookup incomplete due to source errors/throttling — "
+                    "abstention, not evidence of fabrication"
+                )
             if mismatched:
                 reason_parts.append(f"Mismatched: {mismatched}")
             if errors:

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -47,7 +47,10 @@ STATUS_TO_TYPE: dict[str, str] = {
     "doi_mismatch": "hybrid_fabrication",  # cited DOI → different paper
     "given_name_substitution": "swapped_authors",  # co-author given name swapped
     "title_near_miss": "near_miss_title",  # --strict near-miss title
-    "author_truncated": "partial_author_list",  # --strict silent truncation
+    "author_truncated": "partial_author_list",  # silent truncation (default mode post-1.2.0)
+    # Post-1.2.0 positive-evidence statuses — decided problems, never Stage 2
+    "nonexistent_venue": "nonexistent_venue",  # venue unknown to DBLP/OpenAlex registries
+    "unpublished_at_claimed_venue": "preprint_as_published",  # real paper, not at cited venue
     # not_found / unconfirmed / partial_match / api_error / skipped / missing → Stage 2
 }
 
@@ -63,6 +66,9 @@ STAGE1_VERIFIED: set[str] = {
 
 # Statuses routed to Stage 2 for diagnosis.
 ROUTE_TO_STAGE2: set[str] = {
+    # ``not_found`` covers both clean exhaustive misses and coverage-incomplete
+    # lookups (post-1.2.0 ``coverage_incomplete`` — sources errored / were
+    # throttled); both shapes are uncertain and defer to Stage 2.
     "not_found",
     "partial_match",
     "api_error",

--- a/hallmark/baselines/prescreening.py
+++ b/hallmark/baselines/prescreening.py
@@ -39,16 +39,70 @@ class PreScreenResult:
     check_name: str
 
 
+# --- DOI normalization (mirrors bibtex-updater's normalize_doi_for_resolution) ---
+
+# Leading resolver-URL prefix: https://doi.org/..., http://dx.doi.org/...
+_DOI_URL_PREFIX_RE = re.compile(r"^https?://(dx\.)?doi\.org/", re.IGNORECASE)
+
+# Core DOI shape: "10.<registrant>/<suffix>".
+_DOI_CORE_RE = re.compile(r"10\.\d+/[^\s]+")
+
+#: arXiv DataCite DOI prefix. arXiv mints *versioned* DOIs
+#: (``10.48550/arXiv.2010.11929v1``), but only the unversioned DOI
+#: (``10.48550/arXiv.2010.11929``) resolves via doi.org — the versioned form
+#: 404s. Stripping the version suffix is therefore safe ONLY for this prefix;
+#: other DOIs may legitimately end in a letter+digit token.
+_ARXIV_DOI_PREFIX = "10.48550/arxiv."
+_ARXIV_VERSION_SUFFIX_RE = re.compile(r"v\d+$", re.IGNORECASE)
+
+
+def normalize_doi_for_resolution(doi: str) -> str | None:
+    """Normalize a raw DOI field value for resolution against doi.org.
+
+    Replicates the normalization bibtex-updater applies before resolving a DOI
+    (``normalize_doi_for_resolution`` in ``bibtex_updater.utils``):
+
+    - strip surrounding whitespace and a leading ``https://doi.org/`` /
+      ``http://dx.doi.org/`` URL prefix, then extract the ``10.<reg>/<suffix>``
+      core;
+    - for arXiv DataCite DOIs (prefix ``10.48550/arXiv.``, case-insensitive),
+      strip a trailing version suffix (``v1``, ``v2``, ...) — the versioned
+      form 404s at doi.org while the unversioned form resolves.
+
+    Returns:
+        The normalized DOI, or None when no DOI core can be extracted.
+    """
+    stripped = _DOI_URL_PREFIX_RE.sub("", doi.strip())
+    core = _DOI_CORE_RE.search(stripped)
+    if core is None:
+        return None
+    normalized = core.group(0)
+    if normalized.lower().startswith(_ARXIV_DOI_PREFIX):
+        normalized = _ARXIV_VERSION_SUFFIX_RE.sub("", normalized)
+    return normalized
+
+
 def check_doi_resolves(entry: BlindEntry) -> PreScreenResult:
     """Check if DOI resolves via HTTP HEAD request.
 
+    The DOI is normalized first (see :func:`normalize_doi_for_resolution`):
+    URL prefixes are stripped and arXiv DataCite version suffixes (``vN``)
+    removed, because versioned arXiv DOIs 404 at doi.org even though the
+    unversioned preprint DOI resolves.
+
+    Only a definitive 404/410 served by doi.org itself flags HALLUCINATED.
+    Anything ambiguous — network errors, timeouts, rate limits (429), bot
+    blocks (403), server errors (5xx), or a 404/410 served by a redirect
+    *target* after doi.org resolved the DOI — returns UNKNOWN so that
+    pre-screening never overrides the tool on transient failures.
+
     Returns:
         VALID (0.85) if DOI resolves
-        HALLUCINATED (0.85) if DOI returns 404
-        UNKNOWN if no DOI, network error, or other HTTP status
+        HALLUCINATED (0.85) if doi.org itself returns 404 or 410
+        UNKNOWN if no DOI, malformed DOI, network error, or any other HTTP status
     """
-    doi = entry.fields.get("doi")
-    if not doi:
+    raw_doi = entry.fields.get("doi")
+    if not raw_doi:
         return PreScreenResult(
             label="UNKNOWN",
             confidence=0.0,
@@ -56,17 +110,20 @@ def check_doi_resolves(entry: BlindEntry) -> PreScreenResult:
             check_name="check_doi_resolves",
         )
 
-    # Normalize DOI (strip URLs like https://doi.org/...)
-    doi_match = re.search(r"10\.\d+/[^\s]+", doi)
-    if doi_match:
-        normalized_doi = doi_match.group(0)
-    else:
+    normalized_doi = normalize_doi_for_resolution(raw_doi)
+    if normalized_doi is None:
         return PreScreenResult(
             label="UNKNOWN",
             confidence=0.0,
-            reason=f"Malformed DOI: {doi}",
+            reason=f"Malformed DOI: {raw_doi}",
             check_name="check_doi_resolves",
         )
+
+    # Reason strings keep the raw DOI; mention the normalization when it changed it.
+    display_doi = raw_doi.strip()
+    norm_note = (
+        f" (normalized to {normalized_doi} for resolution)" if normalized_doi != display_doi else ""
+    )
 
     url = f"https://doi.org/{normalized_doi}"
 
@@ -83,21 +140,36 @@ def check_doi_resolves(entry: BlindEntry) -> PreScreenResult:
             return PreScreenResult(
                 label="VALID",
                 confidence=0.85,
-                reason=f"DOI {normalized_doi} resolves successfully",
+                reason=f"DOI {display_doi} resolves successfully{norm_note}",
                 check_name="check_doi_resolves",
             )
-        elif response.status_code == 404:
+        elif response.status_code in (404, 410):
+            if response.history:
+                # The 404/410 came from a redirect target, not from doi.org: the
+                # DOI is registered (doi.org redirected) but the landing page is
+                # broken or blocks HEAD requests. Not evidence of fabrication.
+                return PreScreenResult(
+                    label="UNKNOWN",
+                    confidence=0.0,
+                    reason=(
+                        f"DOI {display_doi} resolved at doi.org but redirect target "
+                        f"returned HTTP {response.status_code}{norm_note}"
+                    ),
+                    check_name="check_doi_resolves",
+                )
             return PreScreenResult(
                 label="HALLUCINATED",
                 confidence=0.85,
-                reason=f"DOI {normalized_doi} returns 404",
+                reason=f"DOI {display_doi} returns {response.status_code} at doi.org{norm_note}",
                 check_name="check_doi_resolves",
             )
         else:
+            # 403/429/5xx etc.: bot blocks, rate limits, or server errors are
+            # transient — never treated as evidence of fabrication.
             return PreScreenResult(
                 label="UNKNOWN",
                 confidence=0.0,
-                reason=f"DOI {normalized_doi} returned HTTP {response.status_code}",
+                reason=f"DOI {display_doi} returned HTTP {response.status_code}{norm_note}",
                 check_name="check_doi_resolves",
             )
     except (httpx.RequestError, httpx.TimeoutException) as e:

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -1,0 +1,199 @@
+"""Tests for the bibtex-check (bibtex-updater) baseline wrapper.
+
+Covers ``_parse_jsonl_output`` across the tool's output-contract versions:
+pre-1.2.0 records, 1.2.0 realness records (``confidence_score`` /
+``abstained``), and post-1.2.0 records carrying ``coverage_incomplete`` and
+``p_valid``.  No subprocess or network — JSONL output is faked on disk,
+following the pattern of ``TestParseJsonlToRaw`` in
+``test_llm_tool_augmented.py``.
+
+These tests live in their own module (not ``test_baselines.py``) because that
+module is skipped entirely when the optional ``openai`` dependency is absent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hallmark.baselines.bibtexupdater import (
+    STATUS_TO_CONFIDENCE,
+    STATUS_TO_LABEL,
+    _parse_jsonl_output,
+)
+from hallmark.dataset.schema import Prediction
+
+
+def _parse(tmp_path: Path, records: list[dict[str, Any]]) -> list[Prediction]:
+    jsonl_path = tmp_path / "results.jsonl"
+    jsonl_path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return _parse_jsonl_output(jsonl_path, 1.0, len(records))
+
+
+class TestStatusMaps:
+    def test_new_problem_statuses_mapped(self) -> None:
+        assert STATUS_TO_LABEL["nonexistent_venue"] == "HALLUCINATED"
+        assert STATUS_TO_LABEL["unpublished_at_claimed_venue"] == "HALLUCINATED"
+        assert STATUS_TO_CONFIDENCE["nonexistent_venue"] == 0.85
+        assert STATUS_TO_CONFIDENCE["unpublished_at_claimed_venue"] == 0.75
+
+    def test_default_mode_statuses_already_mapped(self) -> None:
+        """Statuses the upgraded tool now emits in default mode were already
+        mapped — keep them HALLUCINATED."""
+        assert STATUS_TO_LABEL["author_truncated"] == "HALLUCINATED"
+        assert STATUS_TO_LABEL["preprint_only"] == "HALLUCINATED"
+
+    def test_every_label_status_has_a_confidence(self) -> None:
+        assert set(STATUS_TO_LABEL) == set(STATUS_TO_CONFIDENCE)
+
+
+class TestParseJsonlOutput:
+    """``_parse_jsonl_output`` across bibtex-check output-contract versions.
+
+    The post-1.2.0 tool adds ``coverage_incomplete`` and ``p_valid`` fields
+    plus new problem statuses; old-format records (including the precomputed
+    reference results) must keep parsing with identical label and confidence.
+    """
+
+    def test_old_format_records_parse_identically(self, tmp_path: Path) -> None:
+        """Regression pin: pre-1.2.0-shaped records (no confidence_score /
+        abstained / p_valid / coverage_incomplete) keep label AND confidence
+        exactly as before."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "a",
+                "status": "not_found",
+                "confidence": 0.8,
+                "mismatched_fields": [],
+                "api_sources": ["crossref"],
+                "errors": [],
+            },
+            {
+                "key": "b",
+                "status": "verified",
+                "confidence": 0.95,
+                "mismatched_fields": [],
+                "api_sources": ["dblp"],
+                "errors": [],
+            },
+            # No confidence field at all → STATUS_TO_CONFIDENCE fallback.
+            {"key": "c", "status": "venue_mismatch"},
+        ]
+        preds = {p.bibtex_key: p for p in _parse(tmp_path, records)}
+        assert preds["a"].label == "HALLUCINATED"
+        assert preds["a"].confidence == 0.8
+        assert preds["a"].reason == "Status: not_found"
+        assert preds["b"].label == "VALID"
+        assert preds["b"].confidence == 0.95
+        assert preds["c"].label == "HALLUCINATED"
+        assert preds["c"].confidence == 0.80
+
+    def test_v12_format_inversion_heuristic_still_applies(self, tmp_path: Path) -> None:
+        """1.2.0-shaped records (confidence_score/abstained but no p_valid)
+        keep the realness-inversion heuristic for HALLUCINATED labels."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "m",
+                "status": "title_mismatch",
+                "confidence": 0.1,
+                "confidence_score": 10.0,
+                "abstained": False,
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "HALLUCINATED"
+        assert pred.confidence == pytest.approx(0.9)  # 1 - 0.1
+
+    def test_new_format_p_valid_on_valid_status(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "v",
+                "status": "verified",
+                "confidence": 0.88,
+                "abstained": False,
+                "coverage_incomplete": False,
+                "p_valid": 0.94,
+                "confidence_score": 88.0,
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+        assert pred.confidence == pytest.approx(0.94)
+
+    def test_new_format_p_valid_on_hallucinated_status(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "h",
+                "status": "nonexistent_venue",
+                "confidence": 0.78,
+                "abstained": False,
+                "coverage_incomplete": False,
+                "p_valid": 0.11,
+                "confidence_score": 78.0,
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "HALLUCINATED"
+        assert pred.confidence == pytest.approx(0.89)  # 1 - p_valid
+
+    def test_not_found_coverage_incomplete_is_abstention(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "x",
+                "status": "not_found",
+                "confidence": 0.45,
+                "abstained": True,
+                "coverage_incomplete": True,
+                "p_valid": 0.5,
+                "confidence_score": 45.0,
+                "errors": ["semanticscholar: 429 Too Many Requests"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+        assert pred.confidence == pytest.approx(0.45)
+        # Reason explains the abstention while keeping the leading raw-status
+        # segment that run_bibtex_check_with_status parses for the cascade.
+        assert pred.reason.startswith("Status: not_found")
+        assert "incomplete" in pred.reason
+        assert "throttling" in pred.reason
+
+    def test_not_found_clean_miss_still_hallucinated(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "y",
+                "status": "not_found",
+                "confidence": 0.45,
+                "abstained": True,
+                "coverage_incomplete": False,
+                "p_valid": 0.35,
+                "confidence_score": 45.0,
+                "errors": [],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "HALLUCINATED"
+        assert pred.confidence == pytest.approx(0.65)  # 1 - p_valid
+
+    def test_coverage_incomplete_informational_for_other_statuses(self, tmp_path: Path) -> None:
+        """coverage_incomplete only rewrites not_found; api_error keeps its
+        conservative-VALID mapping with p_valid-derived confidence."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "e",
+                "status": "api_error",
+                "confidence": 0.0,
+                "abstained": True,
+                "coverage_incomplete": True,
+                "p_valid": 0.5,
+                "confidence_score": 0.0,
+                "errors": ["Exception: boom"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+        assert pred.confidence == pytest.approx(0.5)
+        assert "abstention" not in pred.reason

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -89,6 +89,34 @@ def test_stage1_prescreening_override_is_honored() -> None:
     assert out.source == "prescreening"
 
 
+def test_stage1_new_positive_evidence_statuses_do_not_defer() -> None:
+    """Post-1.2.0 decided-problem statuses must short-circuit at Stage 1 —
+    never re-routed to the Stage 2 LLM as uncertain."""
+    expected_types = {
+        "nonexistent_venue": "nonexistent_venue",
+        "unpublished_at_claimed_venue": "preprint_as_published",
+        "author_truncated": "partial_author_list",
+        "preprint_only": "preprint_as_published",
+    }
+    entry = _entry("k5")
+    raw = _raw("k5", label="HALLUCINATED", confidence=0.5)
+    for status, expected_type in expected_types.items():
+        assert status in STATUS_TO_TYPE
+        assert status not in ROUTE_TO_STAGE2
+        out = _stage1_predict(entry, raw, status)
+        assert out is not None, f"{status} must not defer to Stage 2"
+        assert out.label == "HALLUCINATED"
+        assert out.predicted_hallucination_type == expected_type
+        assert out.cascade_stage == "stage1_db"
+
+
+def test_not_found_still_routes_to_stage2() -> None:
+    """``not_found`` (including coverage-incomplete lookups, which carry the
+    same raw status string) stays uncertain and defers to Stage 2."""
+    assert "not_found" in ROUTE_TO_STAGE2
+    assert _stage1_predict(_entry("k6"), _raw("k6"), "not_found") is None
+
+
 # ---------------------------------------------------------------------------
 # Aggressive fallback
 # ---------------------------------------------------------------------------

--- a/tests/test_prescreening.py
+++ b/tests/test_prescreening.py
@@ -16,6 +16,7 @@ from hallmark.baselines.prescreening import (
     compute_prescreening_breakdown,
     format_prescreening_breakdown,
     merge_with_predictions,
+    normalize_doi_for_resolution,
     prescreen_entry,
 )
 from hallmark.dataset.schema import BenchmarkEntry, Prediction
@@ -238,9 +239,10 @@ class TestCheckDoiResolves:
 
     @patch("hallmark.baselines.prescreening.httpx.head")
     def test_doi_not_found(self, mock_head):
-        """DOI that returns 404 should be flagged as HALLUCINATED."""
+        """DOI that returns 404 from doi.org should be flagged as HALLUCINATED."""
         mock_response = Mock()
         mock_response.status_code = 404
+        mock_response.history = []  # 404 served by doi.org itself, no redirect
         mock_head.return_value = mock_response
 
         entry = BenchmarkEntry(
@@ -271,6 +273,217 @@ class TestCheckDoiResolves:
         assert result.confidence == 0.0
         assert "network error" in result.reason.lower()
         assert result.check_name == "check_doi_resolves"
+
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_versioned_arxiv_doi_not_flagged(self, mock_head):
+        """A versioned arXiv DataCite DOI must be checked in unversioned form.
+
+        Regression test for the measured false-positive bug: the versioned form
+        (``...v1``) 404s at doi.org while the unversioned form resolves, so
+        pre-screening must strip the suffix instead of flagging HALLUCINATED.
+        """
+
+        def head_side_effect(url, **kwargs):
+            resp = Mock()
+            resp.history = []
+            # doi.org resolves the unversioned DOI; the versioned form 404s.
+            if url.lower() == "https://doi.org/10.48550/arxiv.2602.12172":
+                resp.status_code = 200
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_head.side_effect = head_side_effect
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.48550/arXiv.2602.12172v1"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "VALID"
+        assert result.confidence == 0.85
+        # Raw DOI stays in the reason; the normalization is mentioned.
+        assert "10.48550/arXiv.2602.12172v1" in result.reason
+        assert "normalized" in result.reason.lower()
+        mock_head.assert_called_once_with(
+            "https://doi.org/10.48550/arXiv.2602.12172", timeout=10.0, follow_redirects=True
+        )
+
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_doi_url_prefix_and_version_stripped(self, mock_head):
+        """A doi.org URL prefix and arXiv version suffix are both stripped."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.history = []
+        mock_head.return_value = mock_response
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "https://doi.org/10.48550/arXiv.2602.12172v2"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "VALID"
+        assert "10.48550/arXiv.2602.12172v2" in result.reason
+        mock_head.assert_called_once_with(
+            "https://doi.org/10.48550/arXiv.2602.12172", timeout=10.0, follow_redirects=True
+        )
+
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_fabricated_non_arxiv_vn_doi_404_still_flagged(self, mock_head):
+        """Version stripping is scoped to arXiv DOIs.
+
+        A fabricated non-arXiv DOI that happens to end in ``vN`` is checked
+        verbatim and still flagged when doi.org returns 404.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.history = []
+        mock_head.return_value = mock_response
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.9999/fake.journal.v2"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "HALLUCINATED"
+        assert result.confidence == 0.85
+        assert "404" in result.reason
+        mock_head.assert_called_once_with(
+            "https://doi.org/10.9999/fake.journal.v2", timeout=10.0, follow_redirects=True
+        )
+
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_doi_gone_410_flagged(self, mock_head):
+        """410 Gone from doi.org is definitive and flagged like 404."""
+        mock_response = Mock()
+        mock_response.status_code = 410
+        mock_response.history = []
+        mock_head.return_value = mock_response
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.1234/gone"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "HALLUCINATED"
+        assert result.confidence == 0.85
+        assert "410" in result.reason
+
+    @pytest.mark.parametrize("status_code", [403, 429, 500, 503])
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_transient_http_status_not_flagged(self, mock_head, status_code):
+        """Bot blocks (403), rate limits (429), and 5xx must NOT flag HALLUCINATED."""
+        mock_response = Mock()
+        mock_response.status_code = status_code
+        mock_response.history = []
+        mock_head.return_value = mock_response
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.1234/test"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "UNKNOWN"
+        assert result.confidence == 0.0
+        assert str(status_code) in result.reason
+
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_redirect_target_404_not_flagged(self, mock_head):
+        """A 404 from the redirect target is not a doi.org 404 and must not flag.
+
+        doi.org redirected (so the DOI is registered); the landing page merely
+        404s the HEAD request (broken page or bot block).
+        """
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.history = [Mock()]  # doi.org issued a redirect before the 404
+        mock_head.return_value = mock_response
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.1234/registered"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "UNKNOWN"
+        assert result.confidence == 0.0
+        assert "redirect target" in result.reason.lower()
+
+    @patch("hallmark.baselines._cache.time.sleep")
+    @patch("hallmark.baselines.prescreening.httpx.head")
+    def test_timeout_not_flagged(self, mock_head, mock_sleep):
+        """Timeouts are transient — they must return UNKNOWN, never HALLUCINATED."""
+        mock_head.side_effect = httpx.ConnectTimeout("connection timed out")
+
+        entry = BenchmarkEntry(
+            bibtex_key="test_key",
+            bibtex_type="article",
+            fields={"title": "Test", "doi": "10.1234/test"},
+            label="VALID",
+        )
+        result = check_doi_resolves(entry)
+        assert result.label == "UNKNOWN"
+        assert result.confidence == 0.0
+        assert "network error" in result.reason.lower()
+
+
+class TestNormalizeDoiForResolution:
+    """Tests for the normalize_doi_for_resolution helper.
+
+    Mirrors bibtex-updater's ``normalize_doi_for_resolution`` semantics.
+    """
+
+    def test_plain_doi_unchanged(self):
+        assert normalize_doi_for_resolution("10.1234/test") == "10.1234/test"
+
+    def test_url_prefix_stripped(self):
+        assert normalize_doi_for_resolution("https://doi.org/10.1234/test") == "10.1234/test"
+
+    def test_dx_url_prefix_stripped(self):
+        assert normalize_doi_for_resolution("http://dx.doi.org/10.1234/test") == "10.1234/test"
+
+    def test_whitespace_stripped(self):
+        assert normalize_doi_for_resolution("  10.1234/test  ") == "10.1234/test"
+
+    def test_arxiv_version_suffix_stripped(self):
+        assert (
+            normalize_doi_for_resolution("10.48550/arXiv.2602.12172v1")
+            == "10.48550/arXiv.2602.12172"
+        )
+
+    def test_arxiv_prefix_match_case_insensitive(self):
+        assert (
+            normalize_doi_for_resolution("10.48550/ARXIV.2602.12172v12")
+            == "10.48550/ARXIV.2602.12172"
+        )
+
+    def test_arxiv_unversioned_unchanged(self):
+        assert (
+            normalize_doi_for_resolution("10.48550/arXiv.2602.12172") == "10.48550/arXiv.2602.12172"
+        )
+
+    def test_non_arxiv_version_suffix_untouched(self):
+        assert normalize_doi_for_resolution("10.9999/fake.journal.v2") == "10.9999/fake.journal.v2"
+
+    def test_url_prefix_and_version_combined(self):
+        assert (
+            normalize_doi_for_resolution("https://doi.org/10.48550/arXiv.2602.12172v1")
+            == "10.48550/arXiv.2602.12172"
+        )
+
+    def test_malformed_returns_none(self):
+        assert normalize_doi_for_resolution("not-a-doi") is None
 
 
 class TestPrescreenEntry:


### PR DESCRIPTION
## Summary

Two benchmark-side changes from the bibtexupdater code review (companion PR: rpatrik96/bibtexupdater#45). Suite: 951 → **983 passing** (+32 tests, no regressions); ruff/mypy clean.

### 1. Pre-screening DOI normalization (`fe9b2d0`) — measured FP fix

`check_doi_resolves` HEAD-checked the raw DOI at doi.org, so valid arXiv preprints carrying *versioned* DataCite DOIs (`10.48550/arXiv.2602.12172v1` — the versioned form 404s, the unversioned form resolves) were flagged HALLUCINATED, **overriding the tool's correct `verified` verdict on 11/36 test_public and 21/47 dev_public false positives** (~30–45% of the FPR attributed to the bibtexupdater row). Pre-screening now normalizes the DOI the same way the tool does (prefix strip + arXiv version-suffix strip). Also hardened: 410 Gone now flags like 404; a 404 from a *redirect target* (registered DOI, broken landing page) no longer flags; transient errors/bot-blocks confirmed non-flagging. +20 tests.

### 2. Wrapper consumes the upgraded tool's output contract (`9e605f7`)

- New statuses mapped: `nonexistent_venue` → HALLUCINATED (0.85), `unpublished_at_claimed_venue` → HALLUCINATED (0.75)
- `not_found` + `coverage_incomplete: true` (lookup degraded by source errors/throttling) → VALID @ 0.45 as an abstention instead of a hallucination flag — removes the throttling-dependent FP variance (6 test vs 1 dev `not_found` FPs)
- `p_valid` (the tool's new explicit P(entry-is-genuine)) becomes the confidence source for new-format records, replacing the reverse-engineered inversion heuristic — old-format records take the exact pre-existing code path (regression-pinned byte-identical), so precomputed artifacts in `data/v1.0/baseline_results/` are unaffected
- Cascade routing: the two new statuses are decided at Stage 1 (added to `STATUS_TO_TYPE`), not leaked to the LLM stage; coverage-incomplete misses route to Stage 2 as uncertain by construction

**Note**: precomputed reference results and gold labels are untouched. Re-running the benchmark with the upgraded tool (bibtexupdater#45) will produce new numbers; the per-type deltas to watch are `partial_author_list`, `nonexistent_venue`, `wrong_venue`, `preprint_as_published`, `arxiv_version_mismatch` (DR) and the pre-screening-attributed FPR.

https://claude.ai/code/session_01A4DfpdGLj3VFUT7yhcFxUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4DfpdGLj3VFUT7yhcFxUD)_