### PR TITLE
Site feedback: honest failure-mode claims, larger cards, dot overlap, btu links

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -547,12 +547,11 @@
       var m = MODEL[r.tool];
       var tr = el("tr");
       tr.appendChild(el("td", { className: "name-cell" }, [
-        el("span", {
-          className: "dot",
-          style: "display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:7px;background:" + CAT_COLOR[m.category],
-        }),
-        document.createTextNode(m.name),
-        m.tag ? el("span", { className: "cat-tag", text: m.tag }) : null,
+        el("div", { className: "name-flex" }, [
+          el("span", { className: "dot", style: "background:" + CAT_COLOR[m.category] }),
+          el("span", { text: m.name }),
+          m.tag ? el("span", { className: "cat-tag", text: m.tag }) : null,
+        ]),
       ]));
       LB_COLS.slice(1).forEach(function (c) {
         var isBest = m.ranked && best[c.key] !== undefined && r[c.key] === best[c.key];
@@ -611,7 +610,7 @@
       g.appendChild(svgEl("circle", { cx: cx, cy: cy, r: 6, fill: color, stroke: "var(--surface-1)", "stroke-width": 2 }));
       // direct label: try right, then left, then above; tooltip carries it if no room
       var name = m.name;
-      var wEst = name.length * 6.3;
+      var wEst = name.length * 6.8 + 4;
       var candidates = [
         { x: cx + 12 + wEst / 2, y: cy + 4, anchor: "start", tx: cx + 12 },
         { x: cx - 12 - wEst / 2, y: cy + 4, anchor: "end", tx: cx - 12 },

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -465,6 +465,9 @@ table.data th {
 table.data th .arrow { font-size: 10px; color: var(--accent); }
 table.data td { font-variant-numeric: tabular-nums; color: var(--text-primary); }
 table.data td.name-cell { font-weight: 500; white-space: normal; }
+.name-flex { display: flex; align-items: center; gap: 8px; min-width: 180px; }
+.name-flex .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+.name-flex .cat-tag { margin-left: 0; flex: 0 0 auto; }
 table.data td.best { font-weight: 700; }
 table.data tr:hover td { background: var(--accent-wash); }
 .cat-tag {
@@ -635,9 +638,17 @@ footer a { color: var(--text-secondary); }
 
 .hidden { display: none !important; }
 
-.failure-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; }
-.failure-grid .card { margin: 0; display: flex; flex-direction: column; }
+.failure-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 18px; }
+.failure-grid .card { margin: 0; display: flex; flex-direction: column; padding: 24px 26px; }
 .failure-grid .card .viz { margin-top: auto; }
+.failure-grid .card-sub { font-size: 15px; }
+
+.card-limit {
+  font-size: 13.5px;
+  font-weight: 650;
+  color: var(--text-primary);
+  margin: 0 0 16px;
+}
 .failure-num {
   font-size: 12px;
   font-weight: 700;

--- a/site/index.html
+++ b/site/index.html
@@ -92,9 +92,15 @@
           <p class="card-sub">On the 448-entry 2024&ndash;25 temporal supplement, 8 of 12 LLMs
             degrade sharply (FPR 0.59&ndash;0.89); GPT-5.1 rises from 41% to 76%. Only the two
             latest-cutoff models hold near in-distribution levels.</p>
+          <p class="card-sub">Mitigation: a cutoff-aware prompt addendum drives GPT-5.1&rsquo;s
+            post-cutoff FPR to 0% on the entries it still commits to, at the price of heavy
+            abstention (pre-cutoff UNCERTAIN rises to 52.7%). The effect is model-dependent:
+            Sonnet 4.6 instead abstains selectively (48.9% post-cutoff vs 8.7% pre) while
+            halving its committed-entry FPR.</p>
           <p class="card-limit">Limitation: reported as descriptive, following the paper: the
             post-cutoff rise is confounded with whether a model can recall the newer papers
-            at all.</p>
+            at all, and the failure is epistemic miscalibration rather than structural
+            blindness.</p>
           <div class="viz" id="viz-mode3"></div>
         </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -54,18 +54,24 @@
       <h2 class="section-title">Three failure modes</h2>
       <p class="section-lead">HALLMARK evaluates a DOI-lookup baseline, frontier LLMs zero-shot,
         tool-augmented agents, and the co-designed rule-based verifier
-        <code>bibtex-updater</code> (btu). Three failure modes make the headline finding
-        concrete.</p>
+        <a href="https://github.com/rpatrik96/bibtexupdater"><code>bibtex-updater</code></a>
+        (btu). Three failure modes make the headline finding concrete.</p>
       <div class="failure-grid">
         <div class="card">
           <div class="failure-num">Failure mode i</div>
           <h3>Agentic lookups buy recall but inflate false positives</h3>
           <p class="card-sub">A 5-call tool budget lifts GPT-5.1&rsquo;s recall past
             <code>bibtex-updater</code>&rsquo;s, at roughly five times its false-positive rate.
-            The rise comes from the harness&rsquo;s any-no-match flagging, not the base model:
-            in a deterministic re-aggregation over three of the harness&rsquo;s four sources,
-            any-no-match flagging reaches FPR 0.729 where consensus flagging reaches 0.049
-            (it is the any-vs-consensus ordering that transfers, not the absolute level).</p>
+            The evidence points at the harness&rsquo;s any-no-match flagging rather than the
+            base model: in a deterministic re-aggregation over three of the harness&rsquo;s
+            four sources, any-no-match flagging reaches FPR 0.729 where consensus flagging
+            reaches 0.049 (it is the any-vs-consensus ordering that transfers, not the
+            absolute level).</p>
+          <p class="card-limit">Limitations: no prompt ablations for the agentic harness yet,
+            so prompt-level mitigations remain untested; and the two-stage cascade
+            (bibtex-updater &rarr; Sonnet 4.6, co-designed) shows the inflation is not
+            inevitable: it reaches comparable recall at roughly a quarter of the single-stage
+            agentic false-positive rate.</p>
           <div class="viz" id="viz-mode1"></div>
         </div>
         <div class="card">
@@ -75,6 +81,9 @@
             At a venue-realistic ~2% hallucination rate, even the best verifier reaches only
             ~18% precision: the best catch one true hallucination per 6&ndash;9 flags, the most
             aggressive fewer than one in 35.</p>
+          <p class="card-limit">Limitation: these precisions are derived from dev_public
+            detection and false-positive rates at an assumed 2% base rate; they are not
+            measured on a 2%-prevalence corpus.</p>
           <div class="viz" id="viz-mode2"></div>
         </div>
         <div class="card">
@@ -82,8 +91,10 @@
           <h3>Most LLMs over-flag papers published past their training cutoff</h3>
           <p class="card-sub">On the 448-entry 2024&ndash;25 temporal supplement, 8 of 12 LLMs
             degrade sharply (FPR 0.59&ndash;0.89); GPT-5.1 rises from 41% to 76%. Only the two
-            latest-cutoff models hold near in-distribution levels (a descriptive signal,
-            confounded with possible recall of those entries).</p>
+            latest-cutoff models hold near in-distribution levels.</p>
+          <p class="card-limit">Limitation: reported as descriptive, following the paper: the
+            post-cutoff rise is confounded with whether a model can recall the newer papers
+            at all.</p>
           <div class="viz" id="viz-mode3"></div>
         </div>
       </div>
@@ -125,8 +136,9 @@
         in <code>data/v1.0/baseline_results/</code> and the released extension-split metrics.
         Verifiers may abstain (UNCERTAIN): the coverage column shows the share of entries each
         verifier commits to, and headline metrics follow the paper&rsquo;s scoring conventions.
-        <code>bibtex-updater</code> (btu) and its cascades are co-designed with the benchmark
-        and serve as a reference upper bound, excluded from ranking.</p>
+        <a href="https://github.com/rpatrik96/bibtexupdater"><code>bibtex-updater</code></a>
+        (btu) and its cascades are co-designed with the benchmark and serve as a reference
+        upper bound, excluded from ranking.</p>
 
       <div class="filter-block card">
         <div class="filter-row">


### PR DESCRIPTION
Follow-up to #17 from author review:

1. **Failure-mode cards enlarged** (350px min, 15px body) and **scoped honestly**: each card now carries a bold limitation — mode i notes that no prompt ablations exist for the agentic harness yet and that the co-designed two-stage cascade reaches comparable recall without the FPR inflation; mode ii marks the base-rate precisions as derived (Bayes at an assumed 2% base rate), not measured; mode iii keeps the paper's descriptive/confounded framing.
2. **Leaderboard fix**: category dots now sit in a flex row, so they cannot overlap wrapped verifier names.
3. **bibtex-updater links** to https://github.com/rpatrik96/bibtexupdater from both section leads (was footer-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)