### PR TITLE
Site: namespaced category dots + bibtex-updater hero link

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -463,7 +463,7 @@
     clear(catBox);
     D.categories.forEach(function (c) {
       var chip = el("button", { className: "chip" + (RS.cats[c.key] ? " on" : "") }, [
-        el("span", { className: "dot", style: "background:" + CAT_COLOR[c.key] }),
+        el("span", { className: "hm-dot", style: "background:" + CAT_COLOR[c.key] }),
         c.name,
       ]);
       chip.addEventListener("click", function () {
@@ -481,7 +481,7 @@
     D.models.filter(function (m) { return present[m.tool] && RS.cats[m.category]; })
       .forEach(function (m) {
         var chip = el("button", { className: "chip" + (RS.models[m.tool] ? " on" : "") }, [
-          el("span", { className: "dot", style: "background:" + CAT_COLOR[m.category] }),
+          el("span", { className: "hm-dot", style: "background:" + CAT_COLOR[m.category] }),
           m.name,
         ]);
         chip.addEventListener("click", function () {
@@ -548,7 +548,7 @@
       var tr = el("tr");
       tr.appendChild(el("td", { className: "name-cell" }, [
         el("div", { className: "name-flex" }, [
-          el("span", { className: "dot", style: "background:" + CAT_COLOR[m.category] }),
+          el("span", { className: "hm-dot", style: "background:" + CAT_COLOR[m.category] }),
           el("span", { text: m.name }),
           m.tag ? el("span", { className: "cat-tag", text: m.tag }) : null,
         ]),

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -299,7 +299,7 @@ section { padding: 56px 0 8px; }
   border-color: var(--accent);
   color: var(--text-primary);
 }
-.chip .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+
 .chip .count { color: var(--text-muted); font-size: 12px; }
 
 .seg {
@@ -466,7 +466,15 @@ table.data th .arrow { font-size: 10px; color: var(--accent); }
 table.data td { font-variant-numeric: tabular-nums; color: var(--text-primary); }
 table.data td.name-cell { font-weight: 500; white-space: normal; }
 .name-flex { display: flex; align-items: center; gap: 8px; min-width: 180px; }
-.name-flex .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+.hm-dot {
+  display: inline-block;
+  position: static;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  vertical-align: middle;
+}
 .name-flex .cat-tag { margin-left: 0; flex: 0 0 auto; }
 table.data td.best { font-weight: 700; }
 table.data tr:hover td { background: var(--accent-wash); }

--- a/site/index.html
+++ b/site/index.html
@@ -42,6 +42,7 @@
       <a class="btn primary" href="https://arxiv.org/abs/2607.18360">Paper (arXiv:2607.18360)</a>
       <a class="btn" href="https://github.com/rpatrik96/hallmark">Code &amp; data</a>
       <a class="btn" href="https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK">Dataset (HuggingFace)</a>
+      <a class="btn" href="https://github.com/rpatrik96/bibtexupdater">bibtex-updater (tool)</a>
       <a class="btn" href="#cite">Cite</a>
     </div>
     <div class="kpi-row" id="kpi-row"></div>


### PR DESCRIPTION
Two author-feedback items:

1. **Dot/first-letter overlap**: the deployed files render correctly in both Chromium and WebKit (verified against byte-identical live assets), so the overlap seen locally is consistent with an extension injecting styles for the generic class `.dot`. The class is now namespaced to `.hm-dot` with explicit `display:inline-block; position:static; flex:0 0 auto` sizing — immune to that collision in any environment.
2. **bibtex-updater (tool)** button added to the hero link row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)