### PR TITLE
chore: de-anonymize HF mirror metadata + turnkey refresh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ HALLMARK draws on best practices from established benchmarks:
 ## Features
 
 - **Hallucination taxonomy**: 14 types across 3 difficulty tiers (Easy / Medium / Hard)
-- **2,525 annotated entries**: 773 valid (from DBLP) + 1,177 hallucinated with ground truth (public splits)
+- **2,526 annotated entries**: 826 valid + 1,246 hallucinated with ground truth across the public splits, plus a 454-entry hidden split
 - **6 sub-tests per entry**: DOI resolution, title matching, author consistency, venue verification, field completeness, cross-database agreement
 - **Evaluation metrics**: Detection Rate, F1, tier-weighted F1, detect@k, ECE
 - **Built-in baselines**: DOI-only, bibtex-updater, HaRC, verify-citations, LLM-based (OpenAI, Anthropic, OpenRouter), agentic LLMs with tool use, ensemble, DB-first cascade with hallucination-mode diagnosis, plus ports of two recent papers — `hallucitechecker` ([Sakai et al. 2026](https://arxiv.org/abs/2604.26835)) and `checkifexist` ([Abbonato 2026](https://arxiv.org/abs/2602.15871) Algorithm 1) (CiteVerifier and hallucinator are available as wrapper modules but not registered in the default registry)

--- a/croissant.json
+++ b/croissant.json
@@ -49,10 +49,10 @@
   "@type": "sc:Dataset",
   "conformsTo": "http://mlcommons.org/croissant/1.0",
   "name": "HALLMARK",
-  "description": "HALLMARK (HALLucination benchMARK) is a benchmark for evaluating citation metadata verification systems. It contains 2,525 BibTeX entries spanning 14 hallucination types organized into 3 difficulty tiers, with 6 sub-tests per entry covering DOI resolution, title existence, author matching, venue correctness, field completeness, and cross-database agreement. The benchmark targets ML venue citations (NeurIPS, ICML, ICLR, AAAI, CVPR) from 2021-2023 and includes entries generated via systematic perturbation, LLM generation, adversarial crafting, and real-world hallucination collection.",
-  "url": "https://anonymous.4open.science/r/hallmark/",
+  "description": "HALLMARK (HALLucination benchMARK) is a benchmark for evaluating citation metadata verification systems. It contains 2,526 BibTeX entries spanning 14 hallucination types organized into 3 difficulty tiers, with 6 sub-tests per entry covering DOI resolution, title existence, author matching, venue correctness, field completeness, and cross-database agreement. The benchmark targets ML venue citations (NeurIPS, ICML, ICLR, AAAI, CVPR) from 2021-2023 and includes entries generated via systematic perturbation, LLM generation, adversarial crafting, and real-world hallucination collection.",
+  "url": "https://github.com/rpatrik96/hallmark",
   "license": "https://spdx.org/licenses/MIT.html",
-  "version": "1.0",
+  "version": "1.2.2",
   "datePublished": "2026-05-04",
   "inLanguage": "en",
   "isLiveDataset": false,
@@ -68,9 +68,12 @@
   ],
   "creator": [
     {
-      "@type": "Organization",
-      "name": "Anonymous",
-      "description": "Authors withheld for double-blind review"
+      "@type": "Person",
+      "name": "Patrik Reizinger"
+    },
+    {
+      "@type": "Person",
+      "name": "Wieland Brendel"
     }
   ],
   "distribution": [
@@ -408,5 +411,5 @@
   "rai:dataUseCases": "Intended uses: (1) evaluating and benchmarking citation-verification tools (DOI lookups, metadata cross-referencing, LLM-based verifiers, ensembles); (2) ablation studies over the six per-entry sub-tests (DOI resolution, title existence, author matching, venue correctness, field completeness, cross-database agreement); (3) cross-tool ranking via Plackett-Luce on incomplete coverage; (4) temporal contamination analysis via post-cutoff splits; (5) expanding the taxonomy with community-contributed entries through the documented contribution pipeline. Out-of-scope uses: training generative models to produce convincing fake citations; constructing adversarial examples intended to deceive readers or peer reviewers; any use that violates the MIT license or the terms of service of upstream data sources (DBLP, CrossRef, Semantic Scholar, arXiv).",
   "rai:hasSyntheticData": true,
   "rai:syntheticDataExplanation": "Approximately 60% of the benchmark consists of synthetically generated hallucinated entries produced through four pipelines: (1) systematic perturbation of real entries following 14 deterministic taxonomy-driven rules; (2) LLM-generated entries from multiple models (GPT-5.1, Claude Sonnet 4.5, DeepSeek-R1, DeepSeek-V3, Qwen, Gemini Flash); (3) adversarial hand-crafted entries designed to defeat specific verification strategies; (4) real-world hallucinations collected from documented incidents (GPTZero NeurIPS 2025 audit, GhostCite, HalluCitation). Valid entries (~40%) are not synthetic \u2014 they are scraped from public proceedings and verified against CrossRef and Semantic Scholar.",
-  "citeAs": "@inproceedings{hallmark2026, author = {Anonymous}, title = {HALLMARK: A Benchmark for Citation Hallucination Detection}, booktitle = {Advances in Neural Information Processing Systems (NeurIPS) Track on Evaluations and Datasets}, year = {2026}}"
+  "citeAs": "@misc{reizinger2026hallmarkdiagnosingfailuremodes, title={HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers}, author={Patrik Reizinger and Wieland Brendel}, year={2026}, eprint={2607.18360}, archivePrefix={arXiv}, primaryClass={cs.CR}, url={https://arxiv.org/abs/2607.18360},}"
 }

--- a/hf/README.md
+++ b/hf/README.md
@@ -1,0 +1,275 @@
+---
+license: mit
+language:
+- en
+pretty_name: HALLMARK
+size_categories:
+- 1K<n<10K
+task_categories:
+- text-classification
+- text-retrieval
+tags:
+- citation-verification
+- hallucination-detection
+- llm-evaluation
+- benchmark
+- bibtex
+- academic-writing
+- responsible-ai
+- croissant
+configs:
+  - config_name: default
+    data_files:
+      - split: dev_public
+        path: data/dev_public.parquet
+      - split: test_public
+        path: data/test_public.parquet
+      - split: stress_test
+        path: data/stress_test.parquet
+  - config_name: blind
+    data_files:
+      - split: dev_public
+        path: blind/dev_public_blind.parquet
+      - split: test_public
+        path: blind/test_public_blind.parquet
+      - split: stress_test
+        path: blind/stress_test_blind.parquet
+---
+
+# HALLMARK — Citation Hallucination Detection Benchmark
+
+> **Paper:** [HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers](https://arxiv.org/abs/2607.18360) (Reizinger & Brendel, 2026)
+> **Code & data:** <https://github.com/rpatrik96/hallmark> · **Companion website:** <https://rpatrik96.github.io/hallmark/>
+> **Corpus version:** v1.2.2 (2026-07-22) — see [releases](https://github.com/rpatrik96/hallmark/releases) for provenance of every version.
+
+**HALL**ucination bench**MARK** evaluates citation verification tools on detecting hallucinated references in academic papers. The benchmark was motivated by the NeurIPS 2025 incident in which 53 accepted papers were found to contain fabricated citations that passed peer review.
+
+**TL;DR.** 2,072 public bibliography entries (1,950 in `dev_public`+`test_public`, 122 in `stress_test`), labeled `VALID` or `HALLUCINATED` across 14 fine-grained hallucination types and 3 difficulty tiers, with 6 ground-truth sub-tests per entry.
+
+## At a glance
+
+| Split          | Total | Valid | Hallucinated | Tier 1 / 2 / 3 |
+|----------------|------:|------:|-------------:|---------------:|
+| `dev_public`   | 1,119 |   513 |          606 | 149 / 280 / 177|
+| `test_public`  |   831 |   312 |          519 | 130 / 238 / 151|
+| `stress_test`  |   122 |     1 |          121 |   — / 85 / 36 |
+| `test_hidden`  |   454 |     — |            — |   held out     |
+
+- **14 hallucination types** across 3 difficulty tiers (Easy / Medium / Hard) — see *Taxonomy* below.
+- **6 sub-tests per entry**: DOI resolution, title existence, author match, venue correctness, field completeness, cross-database agreement.
+- **Sources**: DBLP-scraped real citations + perturbations + LLM-generated fakes + real-world hallucinations recovered from NeurIPS 2025 retracted papers (via GPTZero analysis).
+- **License**: MIT.
+
+### Versioning note
+
+The paper's numbers are computed against tag `v1.2.0`. Later releases (`v1.2.1`, `v1.2.2`) replace stale generation-pipeline explanation strings with diagnoses verified against CrossRef/arXiv/DBLP records (per-entry fix logs in the source repository); labels, hallucination types, tiers, sub-tests, and split membership are byte-identical to `v1.2.0`, so every reported number is unaffected.
+
+## Loading
+
+```python
+from datasets import load_dataset
+
+# Default config (all labels visible)
+ds = load_dataset("hallmark-neurips2026/HALLMARK")
+
+# Blind config (labels stripped — for leaderboard submissions)
+blind = load_dataset("hallmark-neurips2026/HALLMARK", "blind")
+```
+
+The `default` config exposes the full schema with ground-truth labels. The `blind` config strips
+`label`, `hallucination_type`, `difficulty_tier`, `explanation`, `subtests`, and provenance
+fields — matching the format an evaluation tool would receive at inference time.
+
+## Schema
+
+Each row is a citation entry with the following fields (default config):
+
+| Field                 | Type           | Description |
+|-----------------------|----------------|-------------|
+| `bibtex_key`          | str            | Stable hex hash key (12 chars) |
+| `bibtex_type`         | str            | `inproceedings`, `article`, `misc`, etc. |
+| `fields`              | dict[str, str] | BibTeX fields: `author`, `title`, `year`, `doi`, `venue`, `pages`, … |
+| `label`               | str            | `VALID` or `HALLUCINATED` |
+| `hallucination_type`  | str / null     | One of 14 types (null for `VALID`) |
+| `difficulty_tier`     | int / null     | 1 (easy), 2 (medium), 3 (hard) |
+| `explanation`         | str / null     | Human-readable annotation rationale |
+| `generation_method`   | str            | `scraped`, `perturbation`, `llm_generated`, `adversarial`, `real_world`, `canary` |
+| `source`              | str            | Source pool identifier |
+| `source_conference`   | str / null     | Originating venue if applicable |
+| `publication_date`    | str / null     | ISO date for temporal contamination analysis |
+| `added_to_benchmark`  | str            | ISO date the entry was added |
+| `subtests`            | dict[str, bool/null] | Six per-entry sub-test ground truths |
+| `raw_bibtex`          | str / null     | Original BibTeX source if preserved |
+| `schema_version`      | str            | Currently `"1.0"` |
+
+The `blind` config keeps only `bibtex_key`, `bibtex_type`, `fields`, and `raw_bibtex`.
+
+## Taxonomy
+
+| Tier | Type                       | Notes |
+|-----:|----------------------------|-------|
+| 1    | `fabricated_doi`           | DOI does not resolve |
+| 1    | `nonexistent_venue`        | Venue does not exist |
+| 1    | `placeholder_authors`      | "John Smith", "First Last", etc. |
+| 1    | `future_date`              | Publication year in the future |
+| 2    | `chimeric_title`           | Title combines fragments from multiple real papers |
+| 2    | `wrong_venue`              | Real paper, wrong venue |
+| 2    | `swapped_authors`          | Authors of a different real paper (a.k.a. *author mismatch*) |
+| 2    | `preprint_as_published`    | Cited as conference paper but only on arXiv |
+| 2    | `hybrid_fabrication`       | Real DOI but fabricated metadata |
+| 3    | `near_miss_title`          | Title close to a real paper, off by a few words |
+| 3    | `plausible_fabrication`    | LLM-generated entries that "look real" — sourced from real NeurIPS 2025 retractions |
+| †    | `merged_citation`          | Two real citations fused into one |
+| †    | `partial_author_list`      | Author list truncated past convention |
+| †    | `arxiv_version_mismatch`   | Wrong arXiv version pin |
+
+† Theoretically-motivated stress-test types (present in all splits; concentrated in `stress_test`).
+
+## Repository layout
+
+```
+.
+├── data/                          # Parquet (default config — full labels)
+├── blind/                         # Parquet (blind config — labels stripped)
+├── jsonl/                         # Original JSONL (lossless source of truth)
+├── sources/                       # Provenance: pre-curation source pools
+├── baseline_results/              # Pre-computed baseline predictions on dev_public
+├── metadata.json                  # Per-split counts and distributions
+├── source_mapping.json            # bibtex_key → source pool mapping
+├── valid_entry_verification.json  # Verification trace for VALID entries
+└── croissant.json                 # Croissant metadata (distributions with SHA-256, record sets, RAI fields)
+```
+
+## Evaluation
+
+Use the [accompanying code repository](https://github.com/rpatrik96/hallmark) to run baselines and the official evaluator:
+
+```bash
+hallmark evaluate --split dev_public --baseline doi_only
+
+hallmark evaluate --split dev_public \
+    --predictions my_predictions.jsonl \
+    --tool-name my-tool
+```
+
+Predictions follow this format:
+
+```json
+{"bibtex_key": "abc123def456", "prediction": "HALLUCINATED", "confidence": 0.91}
+```
+
+### Metrics reported
+
+- **Primary**: Detection Rate, FPR, F1-Hallucination, Tier-weighted F1, Expected Calibration Error (ECE)
+- **Diagnostic**: detect@k, source-stratified metrics, per-subtest accuracy, Plackett-Luce ranking (ONEBench-inspired)
+
+---
+
+## Datasheet
+
+This section follows the *Datasheets for Datasets* template (Gebru et al., 2021).
+
+### Motivation
+- **For what purpose was the dataset created?**
+  To enable rigorous, reproducible evaluation of citation-hallucination detection tools — a category of tools that received intense interest after the NeurIPS 2025 retraction incident exposed widespread fabricated citations passing peer review. No prior benchmark covered this task with controlled difficulty stratification and per-entry diagnostic sub-tests.
+- **Created by.** Patrik Reizinger and Wieland Brendel; see the [paper](https://arxiv.org/abs/2607.18360) for affiliations and acknowledgments.
+
+### Composition
+- **What do instances represent?** Each instance is a single bibliography entry (BibTeX-style record) drawn from real papers, perturbed real entries, LLM-generated fakes, or real-world hallucinations.
+- **How many instances?** 2,526 total (2,072 public + 454 hidden). See *At a glance*.
+- **What data does each instance consist of?** Structured BibTeX fields (`author`, `title`, `year`, `venue`, `doi`, …), label, fine-grained hallucination type, difficulty tier, six sub-test ground truths, and provenance metadata.
+- **Is there a label or target?** Yes: binary `label ∈ {VALID, HALLUCINATED}` plus `hallucination_type` (14 classes) and `difficulty_tier`.
+- **Are there missing values?** `subtests` fields can be `null` when not applicable; `raw_bibtex` is `null` for synthetically constructed entries.
+- **Are relationships made explicit?** Yes — `source_mapping.json` traces each `bibtex_key` to its source pool.
+- **Recommended train/dev/test split.** `dev_public` for development, `test_public` for evaluation, `stress_test` for robustness analysis. `test_hidden` is reserved for a future leaderboard.
+
+### Collection process
+- **How was the data acquired?** Real citations were scraped from DBLP. Perturbed entries were produced by deterministic transformations of real entries (e.g., year shift, author swap, venue substitution). LLM-generated entries were produced by prompting GPT, Claude, DeepSeek, Qwen, Gemini, and Mistral models to fabricate plausible citations. Real-world hallucinations were extracted from the GPTZero NeurIPS 2025 analysis (publicly released).
+- **Time frame.** Real citations are dated 1994–2024 (`publication_date` field). Perturbations and LLM generations were produced in 2026.
+- **Were any ethical review or IRB processes used?** No human subjects data; no IRB review required.
+
+### Preprocessing / cleaning / labeling
+- **Was preprocessing done?** Yes: deduplication via `bibtex_key` hex hash, normalization of BibTeX field names, fuzzy-match guard against title leakage between splits.
+- **How were labels assigned?**
+  - `scraped` entries from DBLP — labeled `VALID` after positive verification (DOI resolves, title in DBLP/OpenAlex, year matches).
+  - `perturbation` entries — labeled `HALLUCINATED` by construction with type recorded.
+  - `llm_generated` and `real_world` entries — labeled `HALLUCINATED` after sub-test panel disagreement.
+- **Ground-truth audit.** A systematic post-release audit corrected entries where real papers were wrongly flagged `HALLUCINATED` (arXiv-DataCite-DOI root cause and faithful truncated author lists); the released corpus is post-relabel, with the flip log in the source repository (`results/reviewer_experiments/relabel_flips.json`).
+- **Verification trace.** `valid_entry_verification.json` records the resolver evidence used for each `VALID` entry.
+
+### Uses
+- **Intended uses.**
+  - Benchmarking citation-verification tools on hallucination detection.
+  - Studying tool calibration (ECE) and tier-stratified failure modes.
+  - Comparing LLM-as-judge approaches against rule-based and retrieval-based verifiers.
+- **Out-of-scope uses.**
+  - **Not** a training set for citation-generation models — using HALLMARK as supervised training data would contaminate downstream evaluation.
+  - **Not** a measure of an LLM's general factuality outside the citation domain.
+  - **Not** a substitute for end-to-end retraction review of any specific paper.
+
+### Distribution
+- **How is the dataset distributed?** HuggingFace Datasets Hub, MIT license, with this card and Croissant metadata (`croissant.json`, including RAI fields).
+- **DOI / persistent identifier.** Provided by HuggingFace upon publication.
+
+### Maintenance
+- **Who maintains the dataset?** Patrik Reizinger. Open an issue at <https://github.com/rpatrik96/hallmark/issues>.
+- **Will the dataset be updated?** Yes. Versioning follows semver-style tags on the source repo (`v1.0`, `v1.1`, …). New hallucination instances are added quarterly; the hidden test split rotates annually to mitigate contamination. See the source repository's `CHANGELOG.md` and [releases](https://github.com/rpatrik96/hallmark/releases).
+- **How can users contribute?** A community contribution interface (`hallmark contribute …` CLI) is documented in the source repo. Submitted entries pass through the same six-sub-test verification pipeline before inclusion.
+- **Will old versions be retained?** Yes — every tagged release is permanently retained as a HuggingFace revision.
+
+---
+
+## Responsible AI considerations
+
+Machine-readable Croissant RAI fields are shipped alongside this card inside `croissant.json` (validated against the [MLCommons Croissant RAI spec](https://github.com/mlcommons/croissant)).
+
+### Bias & representational concerns
+- **Source skew.** Real citations are over-weighted toward NeurIPS, ICML, and ICLR — venues over-represented in DBLP scraping seeds. Tools tuned for medical or humanities citation conventions may underperform on this benchmark.
+- **Author-name distribution.** Names follow real-world author distributions in CS publication corpora; tools relying on phonetic name heuristics may exhibit name-origin disparities.
+- **Language.** English-only.
+
+### Harm-mitigation choices
+- **No PII beyond authorship metadata.** All author names already appear in publicly indexed bibliographies.
+- **DOI prefix safety.** Synthetic `fabricated_doi` entries use a fixed `10.99999/` prefix that is not registered with Crossref, preventing accidental hijack of any real DOI.
+- **No attack uplift.** The benchmark is purely *detection-oriented*; we do not release prompts or pipelines that would meaningfully accelerate the production of plausible-looking fake citations beyond what is already in the public domain.
+
+### Limitations & known issues
+- **Contamination of LLM training data.** LLM-based detectors trained after the NeurIPS 2025 retraction publicity may have seen overlapping content. We recommend reporting `pre_cutoff` vs `post_cutoff` slices via `hallmark evaluate --temporal`.
+- **Stress-test asymmetry.** `stress_test` is overwhelmingly hallucinated (121/122). Use this split for *recall* stress-testing, not for FPR estimation.
+- **Tier boundary subjectivity.** Tier assignment for `near_miss_title` is annotator-judged and may differ between reasonable annotators on borderline cases.
+
+---
+
+## Reproducibility & code
+
+- **Source code:** <https://github.com/rpatrik96/hallmark> (fully executable; MIT license).
+- **Reproduction command:** every split is regeneratable via `python scripts/generate_new_instances.py --reproduce-v1 --seed 8042` against the source pools shipped under `sources/`.
+- **Pre-computed baseline results:** `baseline_results/` includes outputs for `harc`, `bibtexupdater`, and the LLM-agentic OpenAI baseline on `dev_public`, with checksums in `manifest.json`.
+
+### Pre-screening transparency
+
+Baseline wrappers shipped with HALLMARK include a lightweight pre-screening layer that runs *before* the external citation-verification tool (DOI resolution, year bounds, author-count heuristics). Some detections in the `baseline_results/` files therefore originate from this pre-screening step rather than from the underlying tool itself. Any result whose `reason` field starts with `[Pre-screening override]` was flagged by the pre-screening layer; consumers who want tool-only performance should filter these entries out before computing metrics.
+
+## Provenance and contamination
+
+- **Temporal split**: `publication_date` is recorded for every real-world entry, enabling pre/post-cutoff contamination analysis.
+- **Hidden split**: `test_hidden` (454 entries) is **not** included in this release. It is held server-side for an upcoming leaderboard.
+- **Blind format**: Use the `blind` config when reporting numbers from any tool that ingests the dataset directly — it removes any field a tool could shortcut on.
+
+## Citation
+
+```bibtex
+@misc{reizinger2026hallmarkdiagnosingfailuremodes,
+  title={HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers},
+  author={Patrik Reizinger and Wieland Brendel},
+  year={2026},
+  eprint={2607.18360},
+  archivePrefix={arXiv},
+  primaryClass={cs.CR},
+  url={https://arxiv.org/abs/2607.18360},
+}
+```
+
+## License
+
+MIT — see `LICENSE` in the source repository. Source citations themselves are bibliographic metadata in the public domain; perturbed and synthetic entries are released under MIT.

--- a/scripts/upload_to_hf.py
+++ b/scripts/upload_to_hf.py
@@ -1,98 +1,158 @@
-"""Upload HALLMARK dataset to Hugging Face Hub.
+#!/usr/bin/env python3
+"""Refresh the HALLMARK HuggingFace mirror (hallmark-neurips2026/HALLMARK).
+
+Mirrors the LIVE hub layout (which differs from the repo layout):
+
+    jsonl/<split>.jsonl            <- data/v1.0/<split>.jsonl   (6 files)
+    data/<split>.parquet           <- built from jsonl           (3 files)
+    blind/<split>_blind.parquet    <- built from jsonl           (3 files)
+    sources/llm_generated.jsonl    <- data/v1.0/llm_generated.jsonl
+    metadata.json                  <- data/v1.0/metadata.json
+    source_mapping.json            <- data/v1.0/source_mapping.json
+    valid_entry_verification.json  <- data/v1.0/valid_entry_verification.json
+    croissant.json                 <- croissant.json
+    README.md                      <- hf/README.md (dataset card, tracked here)
+
+Parquet files are rebuilt deterministically (pandas + snappy) and their SHA-256
+is verified against croissant.json before anything is uploaded; metadata.json
+is verified the same way. A mismatch aborts the run. Everything ships as one
+hub commit; unchanged blobs are deduplicated server-side.
+
+baseline_results/ on the hub is a separate artifact set and is not touched.
 
 Usage:
-    python scripts/upload_to_hf.py --repo-name <username>/hallmark --token <hf_token>
+    python scripts/upload_to_hf.py [--repo-name hallmark-neurips2026/HALLMARK]
+                                   [--token <hf_token>] [--dry-run]
 
-Requires:
-    pip install huggingface_hub
-
-NOTE FOR MAINTAINERS — dataset card (README.md on HF Hub)
-----------------------------------------------------------
-This script does NOT push a dataset card. After uploading, manually create or update
-the README.md on the HF Hub and include a "Pre-screening transparency" section such as:
-
-    ## Pre-screening transparency
-
-    Baseline wrappers shipped with HALLMARK include a lightweight pre-screening layer
-    that runs *before* the external citation-verification tool (DOI resolution, year
-    bounds, author-count heuristics). Some detections in the ``baseline_results/``
-    files therefore originate from this pre-screening step rather than from the
-    underlying tool itself.  Any result whose ``reason`` field starts with
-    ``[Pre-screening override]`` was flagged by the pre-screening layer.  Consumers
-    who want tool-only performance should filter these entries out before computing
-    metrics.
+Without --token the cached `hf auth login` credential is used.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
+import sys
+import tempfile
 from pathlib import Path
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "v1.0"
-CROISSANT_PATH = Path(__file__).resolve().parent.parent / "croissant.json"
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "data" / "v1.0"
 
-SPLITS = [
-    "dev_public.jsonl",
-    "test_public.jsonl",
-    "stress_test.jsonl",
+JSONL_SPLITS = [
+    "dev_public",
+    "dev_public_blind",
+    "test_public",
+    "test_public_blind",
+    "stress_test",
+    "stress_test_blind",
 ]
 
-BLIND_SPLITS = [
-    "dev_public_blind.jsonl",
-    "test_public_blind.jsonl",
-    "stress_test_blind.jsonl",
-]
+# repo source -> hub path
+STATIC_FILES = {
+    DATA_DIR / "metadata.json": "metadata.json",
+    DATA_DIR / "source_mapping.json": "source_mapping.json",
+    DATA_DIR / "valid_entry_verification.json": "valid_entry_verification.json",
+    DATA_DIR / "llm_generated.jsonl": "sources/llm_generated.jsonl",
+    ROOT / "croissant.json": "croissant.json",
+    ROOT / "hf" / "README.md": "README.md",
+}
+
+PARQUET_HUB_PATHS = {
+    "dev_public": "data/dev_public.parquet",
+    "test_public": "data/test_public.parquet",
+    "stress_test": "data/stress_test.parquet",
+    "dev_public_blind": "blind/dev_public_blind.parquet",
+    "test_public_blind": "blind/test_public_blind.parquet",
+    "stress_test_blind": "blind/stress_test_blind.parquet",
+}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def croissant_checksums() -> dict[str, str]:
+    """Hub path -> expected sha256, from croissant.json's distribution block."""
+    spec = json.loads((ROOT / "croissant.json").read_text(encoding="utf-8"))
+    expected = {}
+    for obj in spec["distribution"]:
+        url = obj.get("contentUrl", "")
+        marker = "/resolve/main/"
+        if marker in url and "sha256" in obj:
+            expected[url.split(marker, 1)[1]] = obj["sha256"]
+    return expected
+
+
+def build_parquets(dst: Path) -> dict[Path, str]:
+    import pandas as pd
+
+    ops: dict[Path, str] = {}
+    for split, hub_path in PARQUET_HUB_PATHS.items():
+        records = [
+            json.loads(line)
+            for line in (DATA_DIR / f"{split}.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        out = dst / hub_path
+        out.parent.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(records).to_parquet(out, index=False, compression="snappy")
+        ops[out] = hub_path
+    return ops
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Upload HALLMARK to Hugging Face Hub")
-    parser.add_argument("--repo-name", required=True, help="HF repo (e.g., username/hallmark)")
-    parser.add_argument("--token", required=True, help="Hugging Face API token")
-    parser.add_argument(
-        "--private", action="store_true", help="Create private repo (for pre-publication)"
-    )
+    parser = argparse.ArgumentParser(description="Refresh the HALLMARK HuggingFace mirror")
+    parser.add_argument("--repo-name", default="hallmark-neurips2026/HALLMARK")
+    parser.add_argument("--token", default=None, help="HF token (default: cached login)")
+    parser.add_argument("--dry-run", action="store_true", help="verify + list, upload nothing")
     args = parser.parse_args()
 
-    try:
-        from huggingface_hub import HfApi
-    except ImportError as err:
-        print("Install huggingface_hub: pip install huggingface_hub")
-        raise SystemExit(1) from err
+    tmp = Path(tempfile.mkdtemp(prefix="hallmark-hf-"))
+    uploads: dict[Path, str] = dict(build_parquets(tmp))
+    for split in JSONL_SPLITS:
+        uploads[DATA_DIR / f"{split}.jsonl"] = f"jsonl/{split}.jsonl"
+    for src, hub_path in STATIC_FILES.items():
+        uploads[src] = hub_path
+
+    missing = [str(p) for p in uploads if not p.exists()]
+    if missing:
+        sys.exit(f"missing source files: {missing}")
+
+    expected = croissant_checksums()
+    by_hub = {hub: src for src, hub in uploads.items()}
+    for hub_path, want in expected.items():
+        got = sha256(by_hub[hub_path])
+        print(f"checksum {'ok' if got == want else 'MISMATCH'}: {hub_path}")
+        if got != want:
+            sys.exit(
+                f"{hub_path}: sha256 {got} does not match croissant.json ({want}); "
+                "regenerate croissant.json or investigate non-determinism before uploading"
+            )
+
+    for src, hub_path in sorted(uploads.items(), key=lambda kv: kv[1]):
+        rel = src.relative_to(ROOT) if src.is_relative_to(ROOT) else src
+        print(f"  {hub_path}  <-  {rel}")
+
+    if args.dry_run:
+        print("dry run: nothing uploaded")
+        return
+
+    from huggingface_hub import CommitOperationAdd, HfApi
 
     api = HfApi(token=args.token)
-
-    # Create repo
-    api.create_repo(
+    print("uploading as:", api.whoami()["name"])
+    version = json.loads((DATA_DIR / "metadata.json").read_text(encoding="utf-8"))["version"]
+    info = api.create_commit(
         repo_id=args.repo_name,
         repo_type="dataset",
-        private=args.private,
-        exist_ok=True,
+        operations=[
+            CommitOperationAdd(path_in_repo=hub, path_or_fileobj=str(src))
+            for src, hub in uploads.items()
+        ],
+        commit_message=f"Refresh mirror to corpus v{version}",
     )
-    print(f"Repository: https://huggingface.co/datasets/{args.repo_name}")
-
-    # Upload data splits
-    for split_file in SPLITS + BLIND_SPLITS:
-        path = DATA_DIR / split_file
-        if path.exists():
-            api.upload_file(
-                path_or_fileobj=str(path),
-                path_in_repo=f"data/{split_file}",
-                repo_id=args.repo_name,
-                repo_type="dataset",
-            )
-            print(f"  Uploaded {split_file}")
-
-    # Upload Croissant metadata
-    if CROISSANT_PATH.exists():
-        api.upload_file(
-            path_or_fileobj=str(CROISSANT_PATH),
-            path_in_repo="croissant.json",
-            repo_id=args.repo_name,
-            repo_type="dataset",
-        )
-        print("  Uploaded croissant.json")
-
-    print(f"\nDone! Dataset available at: https://huggingface.co/datasets/{args.repo_name}")
+    print("commit:", info.commit_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The HF mirror (`hallmark-neurips2026/HALLMARK`) has been stale since 2026-05-06 and still carries double-blind artifacts: anonymous.4open.science links, an "Anonymous" creator, pre-relabel split counts (486/287 valid vs the released 513/312), a 453-entry hidden-split count (actual: 454), and a placeholder citation block.

## What

- **`hf/README.md` (new)**: the dataset card, now tracked in the repo. De-anonymized (paper arXiv:2607.18360, GitHub repo, companion website), post-relabel At-a-glance counts, a versioning note (paper numbers pinned at v1.2.0; v1.2.1/v1.2.2 are explanation-string-only), relabel-audit provenance in the datasheet, the pre-screening transparency section the old uploader docstring asked maintainers to add manually, and the official BibTeX.
- **`croissant.json`**: creators (Reizinger, Brendel), GitHub URL, official `citeAs` (replacing the anonymized placeholder), `version` 1.0 → 1.2.2, entry count 2,525 → 2,526. Distribution checksums untouched.
- **`scripts/upload_to_hf.py`**: rewritten. The old script pushed jsonl files to `data/*`, which would have clobbered the hub's parquet layout. The new one mirrors the live layout exactly (jsonl/, data/ + blind/ parquet, sources/llm_generated.jsonl, metadata/croissant/card), rebuilds the parquets deterministically (verified: byte-identical across runs), and refuses to upload unless every SHA-256 matches croissant.json. `--dry-run` verifies without credentials.
- **`README.md`**: stale pre-relabel counts fixed.

## Verification

- `upload_to_hf.py --dry-run`: all 7 pinned checksums match, 20 files staged with correct hub paths.
- 1034 tests pass, 2 skipped, 1 xfailed.

Note: the actual upload is blocked on HF re-authentication (`hf auth login --force`) — the cached token is invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)