### PR TITLE
fix: keep the HF mirror double-blind for NeurIPS review

### DIFF
--- a/croissant.json
+++ b/croissant.json
@@ -50,7 +50,7 @@
   "conformsTo": "http://mlcommons.org/croissant/1.0",
   "name": "HALLMARK",
   "description": "HALLMARK (HALLucination benchMARK) is a benchmark for evaluating citation metadata verification systems. It contains 2,526 BibTeX entries spanning 14 hallucination types organized into 3 difficulty tiers, with 6 sub-tests per entry covering DOI resolution, title existence, author matching, venue correctness, field completeness, and cross-database agreement. The benchmark targets ML venue citations (NeurIPS, ICML, ICLR, AAAI, CVPR) from 2021-2023 and includes entries generated via systematic perturbation, LLM generation, adversarial crafting, and real-world hallucination collection.",
-  "url": "https://github.com/rpatrik96/hallmark",
+  "url": "https://anonymous.4open.science/r/hallmark/",
   "license": "https://spdx.org/licenses/MIT.html",
   "version": "1.2.2",
   "datePublished": "2026-05-04",
@@ -68,12 +68,9 @@
   ],
   "creator": [
     {
-      "@type": "Person",
-      "name": "Patrik Reizinger"
-    },
-    {
-      "@type": "Person",
-      "name": "Wieland Brendel"
+      "@type": "Organization",
+      "name": "Anonymous",
+      "description": "Authors withheld for double-blind review"
     }
   ],
   "distribution": [
@@ -411,5 +408,5 @@
   "rai:dataUseCases": "Intended uses: (1) evaluating and benchmarking citation-verification tools (DOI lookups, metadata cross-referencing, LLM-based verifiers, ensembles); (2) ablation studies over the six per-entry sub-tests (DOI resolution, title existence, author matching, venue correctness, field completeness, cross-database agreement); (3) cross-tool ranking via Plackett-Luce on incomplete coverage; (4) temporal contamination analysis via post-cutoff splits; (5) expanding the taxonomy with community-contributed entries through the documented contribution pipeline. Out-of-scope uses: training generative models to produce convincing fake citations; constructing adversarial examples intended to deceive readers or peer reviewers; any use that violates the MIT license or the terms of service of upstream data sources (DBLP, CrossRef, Semantic Scholar, arXiv).",
   "rai:hasSyntheticData": true,
   "rai:syntheticDataExplanation": "Approximately 60% of the benchmark consists of synthetically generated hallucinated entries produced through four pipelines: (1) systematic perturbation of real entries following 14 deterministic taxonomy-driven rules; (2) LLM-generated entries from multiple models (GPT-5.1, Claude Sonnet 4.5, DeepSeek-R1, DeepSeek-V3, Qwen, Gemini Flash); (3) adversarial hand-crafted entries designed to defeat specific verification strategies; (4) real-world hallucinations collected from documented incidents (GPTZero NeurIPS 2025 audit, GhostCite, HalluCitation). Valid entries (~40%) are not synthetic \u2014 they are scraped from public proceedings and verified against CrossRef and Semantic Scholar.",
-  "citeAs": "@misc{reizinger2026hallmarkdiagnosingfailuremodes, title={HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers}, author={Patrik Reizinger and Wieland Brendel}, year={2026}, eprint={2607.18360}, archivePrefix={arXiv}, primaryClass={cs.CR}, url={https://arxiv.org/abs/2607.18360},}"
+  "citeAs": "@inproceedings{hallmark2026, author = {Anonymous}, title = {HALLMARK: A Benchmark for Citation Hallucination Detection}, booktitle = {Advances in Neural Information Processing Systems (NeurIPS) Track on Evaluations and Datasets}, year = {2026}}"
 }

--- a/docs/bibliographic_convention_split_plan.md
+++ b/docs/bibliographic_convention_split_plan.md
@@ -1,0 +1,164 @@
+# Proposal: a bibliographic-convention split
+
+**Status:** plan only — nothing implemented, no data added.
+Captured 2026-07-22. Branch: `docs/bibliographic-convention-split`.
+
+## The gap
+
+`docs/v1.1_expansion_brainstorm.md` names **domain-monoculture** as a v1.0
+weakness and addresses it *topically* — `test_crossdomain_matched` moves from ML
+conferences to PubMed. That covers a shift in subject matter. It does not cover a
+shift in **bibliographic convention**, and the benchmark currently has none.
+
+Measured across all three splits (`dev_public` 1119, `test_public` 831,
+`test_crossdomain_matched` 452 — 2402 entries):
+
+| feature | entries |
+|---|---|
+| entry types other than `@inproceedings` / `@article` | **0** |
+| `howpublished` field present | **0** |
+| `editor` present with no `author` | **0** |
+| LaTeX letter-macro accents (`\H`, `\c`, `\k`, `\v`, `\u`, `\r`) | **0** |
+| venue naming a publisher book series (LNCS, CCIS, LNICST, IFIP AICT, SCI) | **0** |
+
+Fields present are exactly `author, title, year, booktitle, doi, url, journal`
+(plus one `volume`/`number`). `test_crossdomain_matched` is PubMed-matched but
+still ASCII `@article`/`@inproceedings`, so it shifts the *subject* while holding
+the *conventions* fixed.
+
+**Consequence.** A tool can be perfect on HALLMARK and still fail systematically
+on a European systems bibliography, a humanities bibliography, or anything using
+`@proceedings`, `@phdthesis`, front matter, or non-ASCII names. The benchmark
+cannot see it either way.
+
+This is not hypothetical. Working on `bibtex-updater` (2026-07-22) we found four
+defects that HALLMARK provably cannot measure — every one of them is inert on all
+2402 entries — yet together they produced a **50% false-positive rate** on a
+held-out set of 44 real, DOI-verified, valid references, falling to **2.3%** once
+fixed. Chief among them: `latex_to_plain` reduced `Heged{\H u}s` to the surname
+key `us` and `Erd{\H o}s` to `os`, so author lists that were character-for-character
+correct scored 0.0 similarity. Any tool sharing that normalization bug scores
+identically on HALLMARK today.
+
+## What a new split would test
+
+Four axes, none currently represented. Each is a *convention*, not a topic, so
+the split is orthogonal to `test_crossdomain_matched`.
+
+1. **Non-ASCII author names in LaTeX escaping** — Hungarian double acute
+   (`{\H o}`, `{\H u}`), Polish ogonek/stroke (`{\k e}`, `{\l}`), Turkish and
+   Romanian cedilla/breve (`{\c c}`, `{\u a}`), Czech caron (`{\v c}`),
+   Scandinavian ring/slash (`{\aa}`, `{\o}`), and the dotless-i form `{\'\i}`.
+2. **Publisher-series venues** — papers whose `booktitle` is the conference but
+   whose indexed container-title is LNCS/CCIS/LNICST/IFIP AICT/SCI.
+3. **Volume-level and non-article entry types** — `@proceedings` (carrying
+   `editor`, no `author`, titled after the conference), `@phdthesis`,
+   `@techreport`.
+4. **Front matter with `howpublished`** — editorials and magazine columns whose
+   venue lives in `howpublished` rather than `journal`.
+
+## Candidate material
+
+### Ready, with caveats: the 44-entry held-out set
+
+Built 2026-07-22 as an independent validation set for the `bibtex-updater` fixes
+(so it must NOT become the benchmark those fixes are then scored on — see
+Contamination). Composition: 14 accented-name entries, 10 Springer/IFIP series
+entries, 5 `@proceedings` with `editor`, 5 `@misc` with `howpublished`, 10 ASCII
+controls. All 44 are VALID; every DOI re-resolved 200 against Crossref.
+
+It usefully separates two failure modes: 8 of the accented entries have the
+diacritics stored **in Crossref itself** (isolating a pure LaTeX-decoding
+failure) while 6 are ASCII-folded upstream (isolating a folding failure).
+
+**Not benchmark-ready as-is.** It is all-VALID, so it measures FPR only and
+cannot produce a detection rate. It is agent-assembled from public metadata and
+has had no second-rater pass.
+
+### High value, but consent-gated: the fabricated given-name cluster
+
+A 192-entry LLM-generated bibliography of one researcher's publication list
+yielded **23 substituted given names across 14 papers**, each confirmed against
+two of DBLP, Crossref and Semantic Scholar. The type is adversarially hard in a
+way the current `swapped_authors` type is not: **21 of 23 preserve the true
+name's first letter and its ethno-linguistic register** (Szabolcs→Sándor,
+Kristóf→Kadosa, Deepak→Dhruvin, Gerald→Germar, Marwa→Muhammad). A surname-only or
+initial-only matcher passes every one. The generator also *shuffled given names
+between entries* rather than inventing them — a within-file signal no current
+entry exercises.
+
+**Consent gate.** This is a real researcher's publication list, and the entries
+are fabricated variants naming real co-authors. Publishing them in a benchmark
+attaches invented authorship to identifiable people. This needs the researcher's
+explicit permission, and probably anonymization of the surnames, before it can
+ship. Do not proceed on this one without that conversation.
+
+### Distinct hard-VALID class: structurally unindexed front matter
+
+The same bibliography contained 15 journal editorials, all verified real, of
+which **14 are absent from Crossref entirely** — the journal deposits DOIs for
+research articles only. Enumerating every DOI under its ISSN returns 300 records,
+all `type: journal-article`; the editorial DOI slots 404.
+
+This is a genuinely different VALID class from anything in v1.0: not "hard to
+find" but *structurally never deposited*. It is the cleanest available test of
+whether a tool distinguishes "no record exists" from "this is fabricated" — and
+it exposes a labelling question the benchmark should answer deliberately (below).
+
+## Design questions to settle first
+
+**1. What does `not_found` mean for an unindexable document?** The harness maps
+`not_found → HALLUCINATED` (rescued to VALID only by `coverage_incomplete`),
+while `unconfirmed → VALID`. For a real-but-never-deposited editorial, a tool
+that abstains is *correct*, yet today it is scored as a false positive. Adding
+these entries without deciding this makes the split unpassable by construction.
+Options: require `unconfirmed`; add a `coverage_incomplete`-style flag for
+structural non-indexing; or score this subset on abstention rather than binary
+label.
+
+**2. Does the split measure FPR only, or both rates?** An all-VALID split is
+cheap, honest, and directly targets the observed failure — but invites a
+degenerate "abstain on everything" baseline. Pairing each convention axis with
+matched HALLUCINATED entries costs much more construction effort. Recommend
+starting FPR-only and saying so explicitly in the split's description.
+
+**3. Where do HALLUCINATED entries come from?** The existing generators
+(`hallmark/generation/`) assume ASCII `@inproceedings`. Fabricating a *plausible*
+LNCS venue or a plausible Hungarian given name is a different generator, and the
+given-name case needs the register-preserving property above or it is trivially
+detectable.
+
+## Contamination and split policy
+
+- **Follow the v1.1 rule: add a new split, do not modify `dev_public`,
+  `test_public`, or `test_crossdomain_matched`.** All published numbers stay
+  valid.
+- **The 44-entry held-out set was used to develop the `bibtex-updater` fixes.**
+  If it ships verbatim, `bibtex-updater` is being scored on its own development
+  set. Either exclude it and rebuild an independent sample by the same recipe, or
+  ship it and label it explicitly as a co-designed split — the README already
+  distinguishes co-designed from independent tools, and this must be recorded the
+  same way.
+- Deduplicate any new DOI against all existing splits before inclusion.
+
+## Suggested sequence
+
+1. Settle the three design questions, especially the `not_found` semantics —
+   everything else depends on it.
+2. Resolve the consent question for the given-name cluster; drop it if the answer
+   is no, the split still stands on axes 1–4.
+3. Rebuild an independent convention sample (target ~150–200) by the held-out
+   recipe, from Crossref/DBLP/OpenAlex, with a second-rater pass on every entry.
+4. Decide FPR-only vs paired, and only then write generators if paired.
+5. Re-run the existing baselines on it. **Expect large movement**: this split is
+   designed to be orthogonal to what v1.0 measures, so a tool near the top of
+   Table 1 may do poorly here. That divergence is the contribution.
+
+## Why this is worth doing
+
+The paper's headline is that recall-optimized verifiers misallocate reviewer
+effort. This split extends that argument along a new axis: tools are tuned on a
+bibliographic monoculture, and the resulting failures fall on non-anglophone
+authors and on document classes outside the ML-conference paper. That is a
+measurable fairness claim, not just a coverage gap — and right now no benchmark
+can substantiate it.

--- a/hf/README.md
+++ b/hf/README.md
@@ -38,9 +38,9 @@ configs:
 
 # HALLMARK — Citation Hallucination Detection Benchmark
 
-> **Paper:** [HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers](https://arxiv.org/abs/2607.18360) (Reizinger & Brendel, 2026)
-> **Code & data:** <https://github.com/rpatrik96/hallmark> · **Companion website:** <https://rpatrik96.github.io/hallmark/>
-> **Corpus version:** v1.2.2 (2026-07-22) — see [releases](https://github.com/rpatrik96/hallmark/releases) for provenance of every version.
+> **Anonymized for NeurIPS 2026 Datasets & Benchmarks Track double-blind review.**
+> Source code: <https://anonymous.4open.science/r/hallmark/>
+> **Corpus version:** v1.2.2 (2026-07-22) — see the source repository's `CHANGELOG.md` and tagged releases for provenance of every version.
 
 **HALL**ucination bench**MARK** evaluates citation verification tools on detecting hallucinated references in academic papers. The benchmark was motivated by the NeurIPS 2025 incident in which 53 accepted papers were found to contain fabricated citations that passed peer review.
 
@@ -62,7 +62,7 @@ configs:
 
 ### Versioning note
 
-The paper's numbers are computed against tag `v1.2.0`. Later releases (`v1.2.1`, `v1.2.2`) replace stale generation-pipeline explanation strings with diagnoses verified against CrossRef/arXiv/DBLP records (per-entry fix logs in the source repository); labels, hallucination types, tiers, sub-tests, and split membership are byte-identical to `v1.2.0`, so every reported number is unaffected.
+The paper's numbers are computed against tag `v1.2.0`. Later releases (`v1.2.1`, `v1.2.2`) replace stale generation-pipeline explanation strings with diagnoses verified against CrossRef/arXiv/DBLP records (per-entry fix logs in the source repository); labels, hallucination types, tiers, sub-tests, and split membership are byte-identical to `v1.2.0`, so every reported number is unaffected. The released corpus is post-relabel throughout: a systematic ground-truth audit corrected entries where real papers were wrongly flagged `HALLUCINATED`.
 
 ## Loading
 
@@ -142,7 +142,7 @@ The `blind` config keeps only `bibtex_key`, `bibtex_type`, `fields`, and `raw_bi
 
 ## Evaluation
 
-Use the [accompanying code repository](https://github.com/rpatrik96/hallmark) to run baselines and the official evaluator:
+Use the [accompanying code repository](https://anonymous.4open.science/r/hallmark/) to run baselines and the official evaluator:
 
 ```bash
 hallmark evaluate --split dev_public --baseline doi_only
@@ -172,7 +172,7 @@ This section follows the *Datasheets for Datasets* template (Gebru et al., 2021)
 ### Motivation
 - **For what purpose was the dataset created?**
   To enable rigorous, reproducible evaluation of citation-hallucination detection tools — a category of tools that received intense interest after the NeurIPS 2025 retraction incident exposed widespread fabricated citations passing peer review. No prior benchmark covered this task with controlled difficulty stratification and per-entry diagnostic sub-tests.
-- **Created by.** Patrik Reizinger and Wieland Brendel; see the [paper](https://arxiv.org/abs/2607.18360) for affiliations and acknowledgments.
+- **Created by.** Anonymized for double-blind review.
 
 ### Composition
 - **What do instances represent?** Each instance is a single bibliography entry (BibTeX-style record) drawn from real papers, perturbed real entries, LLM-generated fakes, or real-world hallucinations.
@@ -212,8 +212,8 @@ This section follows the *Datasheets for Datasets* template (Gebru et al., 2021)
 - **DOI / persistent identifier.** Provided by HuggingFace upon publication.
 
 ### Maintenance
-- **Who maintains the dataset?** Patrik Reizinger. Open an issue at <https://github.com/rpatrik96/hallmark/issues>.
-- **Will the dataset be updated?** Yes. Versioning follows semver-style tags on the source repo (`v1.0`, `v1.1`, …). New hallucination instances are added quarterly; the hidden test split rotates annually to mitigate contamination. See the source repository's `CHANGELOG.md` and [releases](https://github.com/rpatrik96/hallmark/releases).
+- **Who maintains the dataset?** Anonymized for review. Post-acceptance, contact details will be added.
+- **Will the dataset be updated?** Yes. Versioning follows semver-style tags on the source repo (`v1.0`, `v1.1`, …). New hallucination instances are added quarterly; the hidden test split rotates annually to mitigate contamination. See the source repository's `CHANGELOG.md` and tagged releases.
 - **How can users contribute?** A community contribution interface (`hallmark contribute …` CLI) is documented in the source repo. Submitted entries pass through the same six-sub-test verification pipeline before inclusion.
 - **Will old versions be retained?** Yes — every tagged release is permanently retained as a HuggingFace revision.
 
@@ -242,7 +242,7 @@ Machine-readable Croissant RAI fields are shipped alongside this card inside `cr
 
 ## Reproducibility & code
 
-- **Source code:** <https://github.com/rpatrik96/hallmark> (fully executable; MIT license).
+- **Source code:** <https://anonymous.4open.science/r/hallmark/> (fully executable; MIT license).
 - **Reproduction command:** every split is regeneratable via `python scripts/generate_new_instances.py --reproduce-v1 --seed 8042` against the source pools shipped under `sources/`.
 - **Pre-computed baseline results:** `baseline_results/` includes outputs for `harc`, `bibtexupdater`, and the LLM-agentic OpenAI baseline on `dev_public`, with checksums in `manifest.json`.
 
@@ -258,16 +258,9 @@ Baseline wrappers shipped with HALLMARK include a lightweight pre-screening laye
 
 ## Citation
 
-```bibtex
-@misc{reizinger2026hallmarkdiagnosingfailuremodes,
-  title={HALLMARK: Diagnosing Three Failure Modes in LLM Citation Verifiers},
-  author={Patrik Reizinger and Wieland Brendel},
-  year={2026},
-  eprint={2607.18360},
-  archivePrefix={arXiv},
-  primaryClass={cs.CR},
-  url={https://arxiv.org/abs/2607.18360},
-}
+```
+% Anonymized for NeurIPS 2026 D&B double-blind review.
+% Citation BibTeX will be added to this card after acceptance / decision release.
 ```
 
 ## License

--- a/scripts/upload_to_hf.py
+++ b/scripts/upload_to_hf.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Refresh the HALLMARK HuggingFace mirror (hallmark-neurips2026/HALLMARK).
 
+ANONYMITY: the hub dataset is linked in the NeurIPS 2026 submission and must
+stay double-blind until the decision. Every staged file is scanned for
+de-anonymizing strings (author names, GitHub handle, arXiv ID) and the run
+aborts on a hit; pass --allow-deanonymized only after the review period ends.
+
 Mirrors the LIVE hub layout (which differs from the repo layout):
 
     jsonl/<split>.jsonl            <- data/v1.0/<split>.jsonl   (6 files)
@@ -68,6 +73,10 @@ PARQUET_HUB_PATHS = {
 }
 
 
+# strings that would break double-blind review if they reached the hub
+DEANONYMIZING_MARKERS = [b"Reizinger", b"Brendel", b"rpatrik96", b"2607.18360"]
+
+
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -106,6 +115,11 @@ def main() -> None:
     parser.add_argument("--repo-name", default="hallmark-neurips2026/HALLMARK")
     parser.add_argument("--token", default=None, help="HF token (default: cached login)")
     parser.add_argument("--dry-run", action="store_true", help="verify + list, upload nothing")
+    parser.add_argument(
+        "--allow-deanonymized",
+        action="store_true",
+        help="skip the double-blind marker scan (post-decision only)",
+    )
     args = parser.parse_args()
 
     tmp = Path(tempfile.mkdtemp(prefix="hallmark-hf-"))
@@ -118,6 +132,18 @@ def main() -> None:
     missing = [str(p) for p in uploads if not p.exists()]
     if missing:
         sys.exit(f"missing source files: {missing}")
+
+    if not args.allow_deanonymized:
+        for src, hub_path in uploads.items():
+            blob = src.read_bytes()
+            hits = [m.decode() for m in DEANONYMIZING_MARKERS if m in blob]
+            if hits:
+                sys.exit(
+                    f"ANONYMITY VIOLATION: {hub_path} contains {hits}; the hub dataset "
+                    "is double-blind for NeurIPS 2026 review. Fix the file or, after "
+                    "the decision, rerun with --allow-deanonymized."
+                )
+        print("anonymity scan: clean")
 
     expected = croissant_checksums()
     by_hub = {hub: src for src, hub in uploads.items()}


### PR DESCRIPTION
## Why

The hub dataset (`hallmark-neurips2026/HALLMARK`) is linked in the NeurIPS 2026 submission and must stay anonymized until the decision. PR #23 de-anonymized the HF-bound artifacts; nothing was ever uploaded (the refresh is blocked on HF auth), but the prepared content would have broken the blind on the next run.

## What

- **`hf/README.md`**: back to the double-blind register (anonymization blockquote, anonymous.4open.science links, anonymized datasheet/maintenance, placeholder citation). The factual fixes stay: post-relabel counts, hidden-split 454, corpus-version + versioning note, relabel-audit provenance, pre-screening transparency section, `croissant.json` layout reference.
- **`croissant.json`**: creator back to Anonymous, URL back to anonymous.4open.science, `citeAs` back to the anonymized placeholder. Keeps version 1.2.2 and the 2,526 count. Distribution checksums untouched.
- **`scripts/upload_to_hf.py`**: every staged file is scanned for de-anonymizing strings (author names, GitHub handle, arXiv ID) and the run aborts on a hit — an accidental future upload cannot break the blind. `--allow-deanonymized` lifts the guard post-decision. Verified the HF-bound data files contain none of the markers, so no false positives.

## Verification

`--dry-run`: anonymity scan clean, all 7 pinned checksums match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)