### PR TITLE
feat/cascade-gpt51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ dist/
 build/
 .eggs/
 
+# Secrets — API keys are read from the environment, never committed
+.env
+.env.*
+!.env.example
+
 # Virtual environments
 .venv/
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ HALLMARK applies a pre-screening layer (DOI resolution, year bounds, author heur
 ```python
 from hallmark.baselines.common import run_with_prescreening
 
+
 def run_my_tool(entries):
     return run_with_prescreening(
         entries=entries,

--- a/README.md
+++ b/README.md
@@ -338,9 +338,9 @@ Any real tool that achieves F1 below the title oracle on the hidden split is arg
 from hallmark.baselines.title_oracle import run_title_oracle
 from hallmark.dataset.loader import load_split
 
-dev_entries  = load_split("dev_public")
+dev_entries = load_split("dev_public")
 test_entries = load_split("test_public")
-blind_test   = [e.to_blind() for e in test_entries]
+blind_test = [e.to_blind() for e in test_entries]
 
 predictions = run_title_oracle(blind_test, reference_pool=dev_entries)
 ```
@@ -447,10 +447,7 @@ from hallmark.dataset.schema import Prediction
 entries = load_split("dev_public")
 
 # Create predictions (your tool's output)
-predictions = [
-    Prediction(bibtex_key=e.bibtex_key, label="VALID", confidence=0.5)
-    for e in entries
-]
+predictions = [Prediction(bibtex_key=e.bibtex_key, label="VALID", confidence=0.5) for e in entries]
 
 # Evaluate
 result = evaluate(entries, predictions, tool_name="my-tool", split_name="dev_public")

--- a/hallmark/baselines/_agentic_tools.py
+++ b/hallmark/baselines/_agentic_tools.py
@@ -13,15 +13,77 @@ Tool set mirrors bibtex-updater's lookup sources:
 
 from __future__ import annotations
 
+import email.utils
 import logging
 import re
 import urllib.parse
 import urllib.request
+from typing import Any
+
+from hallmark.baselines._cache import RateLimitedError
 
 logger = logging.getLogger(__name__)
 
 _MAX_FIELD_CHARS = 500
 _OPENALEX_MAILTO = "hallmark@example.com"
+
+# ``export.arxiv.org`` is markedly slower than the other metadata sources and is the
+# only one that produced read timeouts in the 2026-07 cascade run (~29 lookups lost at
+# a 15s ceiling, each after three retries). Give it a longer allowance than the rest.
+_ARXIV_TIMEOUT_SECONDS = 30.0
+
+# Status codes that mean "you are being throttled, come back later" rather than
+# "this request was wrong". Both may carry a ``Retry-After`` header.
+_THROTTLE_STATUS_CODES = frozenset({429, 503})
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header into a number of seconds.
+
+    RFC 9110 permits two forms: delta-seconds (``"30"``) or an HTTP-date
+    (``"Wed, 21 Oct 2026 07:28:00 GMT"``). Both are accepted.
+
+    Args:
+        value: Raw header value, or ``None`` when the server omitted it.
+
+    Returns:
+        Seconds to wait, or ``None`` if absent, unparseable, or already elapsed.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        when = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    import datetime as _dt
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=_dt.timezone.utc)
+    delta = (when - now).total_seconds()
+    return max(0.0, delta) if delta > 0 else None
+
+
+def _raise_for_throttle(resp: Any, source: str) -> None:
+    """Raise :class:`RateLimitedError` carrying ``Retry-After`` if *resp* is throttled.
+
+    Args:
+        resp: The HTTP response to inspect.
+        source: Human-readable source name used in the error message.
+    """
+    if resp is None or resp.status_code not in _THROTTLE_STATUS_CODES:
+        return
+    retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+    if retry_after is not None:
+        logger.debug("%s asked us to retry after %.1fs", source, retry_after)
+    raise RateLimitedError(f"{source} returned HTTP {resp.status_code}", retry_after=retry_after)
 
 
 def _trunc(value: object) -> str:
@@ -76,6 +138,7 @@ def resolve_doi(doi: str) -> dict[str, str]:
 
     if resp.status_code == 404:
         raise ValueError(f"DOI not found: {normalized_doi}")
+    _raise_for_throttle(resp, "CrossRef")
     if resp.status_code != 200:
         raise RuntimeError(f"CrossRef returned HTTP {resp.status_code} for {normalized_doi}")
 
@@ -135,6 +198,7 @@ def search_crossref(query: str, limit: int = 5) -> list[dict[str, str]]:
     except httpx.RequestError as exc:
         raise RuntimeError(f"CrossRef search network error: {exc}") from exc
 
+    _raise_for_throttle(resp, "CrossRef search")
     if resp.status_code != 200:
         raise RuntimeError(f"CrossRef search returned HTTP {resp.status_code}")
 
@@ -199,6 +263,7 @@ def search_openalex(query: str, limit: int = 5) -> list[dict[str, str]]:
     except httpx.RequestError as exc:
         raise RuntimeError(f"OpenAlex search network error: {exc}") from exc
 
+    _raise_for_throttle(resp, "OpenAlex")
     if resp.status_code != 200:
         raise RuntimeError(f"OpenAlex returned HTTP {resp.status_code}")
 
@@ -257,10 +322,11 @@ def search_arxiv(query: str, limit: int = 5) -> list[dict[str, str]]:
     url = "https://export.arxiv.org/api/query?" + urllib.parse.urlencode(params)
 
     try:
-        resp = httpx.get(url, timeout=15.0, follow_redirects=True)
+        resp = httpx.get(url, timeout=_ARXIV_TIMEOUT_SECONDS, follow_redirects=True)
     except httpx.RequestError as exc:
         raise RuntimeError(f"arXiv search network error: {exc}") from exc
 
+    _raise_for_throttle(resp, "arXiv")
     if resp.status_code != 200:
         raise RuntimeError(f"arXiv returned HTTP {resp.status_code}")
 
@@ -358,6 +424,7 @@ def search_semantic_scholar(query: str, limit: int = 5) -> list[dict[str, str]]:
             continue
         break
 
+    _raise_for_throttle(resp, "Semantic Scholar")
     if resp is None or resp.status_code != 200:
         code = resp.status_code if resp is not None else "no-response"
         raise RuntimeError(f"Semantic Scholar returned HTTP {code}")

--- a/hallmark/baselines/_cache.py
+++ b/hallmark/baselines/_cache.py
@@ -24,6 +24,11 @@ T = TypeVar("T")
 
 _DEFAULT_CACHE_DIR = Path.home() / ".cache" / "hallmark"
 
+# Upper bound on a honoured ``Retry-After``. Servers occasionally answer with windows
+# of an hour or more; sleeping that long would stall an evaluation run, so we wait at
+# most this and let the normal retry budget expire.
+MAX_RETRY_AFTER_SECONDS = 60.0
+
 _BENCHMARK_VERSION = "1.0"
 
 # Sentinel object used to distinguish "key absent" from a cached falsy value.
@@ -129,6 +134,40 @@ def cached_call(
     return result
 
 
+class RateLimitedError(RuntimeError):
+    """An upstream throttle (HTTP 429/503) that told us how long to wait.
+
+    Servers answering 429 usually include a ``Retry-After`` header stating when the
+    caller may return.  Ignoring it and falling back to a fixed exponential schedule
+    means retrying *before* the window reopens and exhausting the budget while being
+    told exactly how to succeed — the shape of the 173 Semantic Scholar and 149
+    OpenAlex failures in the 2026-07 cascade run.
+
+    Attributes:
+        retry_after: Seconds to wait as instructed by the server, or ``None`` when the
+            header was absent or unparseable (callers then fall back to exponential
+            backoff).
+    """
+
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class NonRetryableError(RuntimeError):
+    """An error that is guaranteed to recur identically on every attempt.
+
+    Raised for deterministic, client-side faults (e.g. decoding a response body
+    we ourselves mislabelled) as opposed to transient network conditions such as
+    HTTP 429, timeouts, or connection resets.  :func:`retry_with_backoff` re-raises
+    these immediately instead of sleeping through a backoff schedule that cannot
+    change the outcome.
+
+    Failing fast also keeps the diagnosis honest: four retries and a backoff make
+    a code defect look like a struggling upstream API.
+    """
+
+
 def retry_with_backoff(
     fn: Callable[[], T],
     max_retries: int = 3,
@@ -136,6 +175,15 @@ def retry_with_backoff(
     exceptions: tuple[type[BaseException], ...] = (Exception,),
 ) -> T:
     """Retry *fn* with exponential backoff on failure.
+
+    Three classes of failure are treated differently:
+
+    - :class:`NonRetryableError` — deterministic client-side fault; re-raised on the
+      first attempt, since retrying cannot change the outcome.
+    - :class:`RateLimitedError` carrying ``retry_after`` — the server stated when to
+      return, so that wait is honoured (capped at :data:`MAX_RETRY_AFTER_SECONDS`)
+      in place of the exponential schedule.
+    - Everything else — ordinary transient errors; exponential backoff.
 
     Args:
         fn: Zero-argument callable.
@@ -155,17 +203,35 @@ def retry_with_backoff(
     for attempt in range(max_retries + 1):
         try:
             return fn()
+        except NonRetryableError as exc:
+            # Deterministic client-side fault — retrying cannot change the result.
+            # Logged at ERROR (not WARNING) because it signals a bug in our code,
+            # not an unhealthy upstream API.
+            logger.error("Non-retryable error, failing immediately: %s", exc)
+            raise
         except exceptions as exc:
             last_exc = exc
+            # Honour a server-stated Retry-After in place of our own guess: retrying
+            # sooner than instructed is guaranteed to be refused again.
+            wait = delay
+            requested = getattr(exc, "retry_after", None)
+            if isinstance(requested, (int, float)) and requested > 0:
+                wait = min(float(requested), MAX_RETRY_AFTER_SECONDS)
+                if float(requested) > MAX_RETRY_AFTER_SECONDS:
+                    logger.warning(
+                        "Server asked for %.0fs, capping wait at %.0fs",
+                        float(requested),
+                        MAX_RETRY_AFTER_SECONDS,
+                    )
             if attempt < max_retries:
                 logger.warning(
                     "Attempt %d/%d failed (%s), retrying in %.1fs...",
                     attempt + 1,
                     max_retries + 1,
                     exc,
-                    delay,
+                    wait,
                 )
-                time.sleep(delay)
+                time.sleep(wait)
                 delay *= 2
             else:
                 logger.error(

--- a/hallmark/baselines/_cache.py
+++ b/hallmark/baselines/_cache.py
@@ -12,7 +12,7 @@ import importlib.util
 import logging
 import shelve
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 _DEFAULT_CACHE_DIR = Path.home() / ".cache" / "hallmark"
+
+# CLI flags whose *value* is a credential and must never reach a log file.
+_SECRET_FLAGS = frozenset({"--s2-api-key", "--api-key", "--openai-api-key", "--token"})
 
 # Upper bound on a honoured ``Retry-After``. Servers occasionally answer with windows
 # of an hour or more; sleeping that long would stall an evaluation run, so we wait at
@@ -132,6 +135,38 @@ def cached_call(
     _locked_shelve_write(db_path, key, result)
     logger.debug("Cache miss: %s/%s — stored", versioned_namespace, key[:12])
     return result
+
+
+def redact_command(cmd: Sequence[str]) -> str:
+    """Render a subprocess command for logging with secret values masked.
+
+    Flags such as ``--s2-api-key`` take the credential as the *following*
+    argument, so logging ``" ".join(cmd)`` writes a live key into every log line
+    (a 121-entry run emitted 242 copies before this was added).
+
+    Args:
+        cmd: The command and its arguments.
+
+    Returns:
+        A space-joined rendering with the value after any secret-bearing flag
+        replaced by ``***``.
+    """
+    parts = list(cmd)
+    out: list[str] = []
+    mask_next = False
+    for part in parts:
+        if mask_next:
+            out.append("***")
+            mask_next = False
+            continue
+        flag = part.split("=", 1)[0]
+        if flag in _SECRET_FLAGS:
+            # Both "--flag value" and "--flag=value" spellings.
+            out.append(f"{flag}=***" if "=" in part else part)
+            mask_next = "=" not in part
+        else:
+            out.append(part)
+    return " ".join(out)
 
 
 class RateLimitedError(RuntimeError):

--- a/hallmark/baselines/_http_cache.py
+++ b/hallmark/baselines/_http_cache.py
@@ -33,11 +33,18 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from hallmark.baselines._cache import NonRetryableError
+
 # 30 days in seconds.
 _CACHE_TTL_SECONDS = 30 * 24 * 60 * 60
 
 # Headers we want to ignore when matching cached responses.
 _IGNORED_HEADERS = ("User-Agent",)
+
+# Response headers that describe the compressed wire format and therefore go stale
+# the moment ``requests`` decompresses the body for us.  Compared case-insensitively
+# because HTTP header names are case-insensitive.
+_STALE_HEADERS = frozenset({"content-encoding", "content-length"})
 
 
 @contextmanager
@@ -93,12 +100,26 @@ def http_cache(cache_path: Path | None) -> Iterator[None]:
         """Adapt a ``requests.Response`` to a duck-typed ``httpx.Response``-ish object."""
         # Build an httpx.Response so callers using .status_code/.text/.json() work.
         content = resp.content if hasattr(resp, "content") else b""
-        headers = dict(resp.headers) if hasattr(resp, "headers") else {}
-        return httpx.Response(
-            status_code=int(resp.status_code),
-            headers=headers,
-            content=content,
-        )
+        # ``requests`` has already decompressed the body, so the transfer-encoding
+        # headers describe bytes we no longer hold: ``Content-Encoding`` would make
+        # httpx decompress plain text (zlib "Error -3 ... incorrect header check"),
+        # and ``Content-Length`` still reports the *compressed* size.  Drop both —
+        # they describe the wire format, not the payload we are handing over.
+        raw_headers = dict(resp.headers) if hasattr(resp, "headers") else {}
+        headers = {k: v for k, v in raw_headers.items() if k.lower() not in _STALE_HEADERS}
+        try:
+            return httpx.Response(
+                status_code=int(resp.status_code),
+                headers=headers,
+                content=content,
+            )
+        except httpx.DecodingError as exc:
+            # Should be unreachable now that the stale headers are stripped, but a
+            # decode failure here is always a client-side defect, never a transient
+            # network condition — surface it immediately rather than retrying it.
+            raise NonRetryableError(
+                f"failed to adapt cached response for {getattr(resp, 'url', '?')}: {exc}"
+            ) from exc
 
     def _cached_request(method: str, url: str, **kwargs: Any) -> Any:
         # Drop httpx-only kwargs requests doesn't recognise.

--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -36,6 +36,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from hallmark.baselines._cache import redact_command
 from hallmark.baselines.common import entries_to_bib, fallback_predictions, run_with_prescreening
 from hallmark.dataset.schema import BlindEntry, Prediction
 
@@ -337,8 +338,8 @@ def _run_bibtex_check_subprocess(
         if extra_args:
             cmd.extend(extra_args)
 
-        # Run bibtex-check
-        logger.info(f"Running: {' '.join(cmd)}")
+        # Run bibtex-check (the API key is masked — see redact_command)
+        logger.info(f"Running: {redact_command(cmd)}")
         timed_out = False
         try:
             result = subprocess.run(

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -21,6 +21,7 @@ evaluation surfaces as the DB-indexing-lag tax.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from hallmark.baselines.bibtexupdater import run_bibtex_check_with_status
@@ -202,6 +203,17 @@ def run_cascade(
     if not entries:
         return []
 
+    # The harness injects ``checkpoint_dir`` for baselines that support
+    # per-entry resume. Stage 1 (bibtex-check subprocess) has no checkpoint
+    # support and would silently swallow it via ``**_kw`` — route it to the
+    # Stage 2 LLM baseline instead, under a subdirectory so the top-level
+    # resume scan (which globs ``checkpoint_dir/*.jsonl``, non-recursive)
+    # does not skip entries before they re-enter the cascade for Stage 1
+    # verdicts and stage tagging. On resume, Stage 1 re-runs (cheap,
+    # disk-cached by the tool) and Stage 2 returns checkpointed predictions
+    # without new LLM calls.
+    checkpoint_dir = stage1_kwargs.pop("checkpoint_dir", None)
+
     stage1_preds, status_map = run_bibtex_check_with_status(entries, **stage1_kwargs)
     pred_by_key = {p.bibtex_key: p for p in stage1_preds}
 
@@ -223,7 +235,10 @@ def run_cascade(
             final[key] = verdict
 
     if deferred:
-        stage2_preds = _run_stage2(deferred, stage2_baseline, stage2_kwargs or {})
+        merged_stage2: dict[str, Any] = dict(stage2_kwargs or {})
+        if checkpoint_dir is not None:
+            merged_stage2.setdefault("checkpoint_dir", Path(checkpoint_dir) / "stage2")
+        stage2_preds = _run_stage2(deferred, stage2_baseline, merged_stage2)
         for p in stage2_preds:
             tagged = Prediction(
                 bibtex_key=p.bibtex_key,

--- a/hallmark/baselines/llm_tool_augmented.py
+++ b/hallmark/baselines/llm_tool_augmented.py
@@ -17,6 +17,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from hallmark.baselines._cache import redact_command
 from hallmark.baselines.common import entries_to_bib
 from hallmark.dataset.schema import BlindEntry, Prediction
 
@@ -161,7 +162,7 @@ def save_tool_evidence(
         if extra_args:
             cmd.extend(extra_args)
 
-        logger.info(f"Running bibtex-check for tool evidence: {' '.join(cmd)}")
+        logger.info(f"Running bibtex-check for tool evidence: {redact_command(cmd)}")
         try:
             subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         except FileNotFoundError:

--- a/hallmark/baselines/registry.py
+++ b/hallmark/baselines/registry.py
@@ -644,6 +644,41 @@ def _register_builtins() -> None:
         )
     )
 
+    # --- LLM: Agentic OpenRouter GPT-5.1 ---
+    # Routes the OpenAI-compatible agentic harness through OpenRouter to use
+    # openai/gpt-5.1 without a native OpenAI API key. Drop-in replacement for
+    # llm_agentic_openai; the GPT-5.1 counterpart of
+    # llm_agentic_openrouter_claude_sonnet_4_6, intended as the Stage 2 diagnoser
+    # for cascade_db_diagnosis GPT-5.1 comparison runs under a lab OpenRouter key.
+    def _run_llm_agentic_openrouter_gpt_5_1(
+        entries: list[BlindEntry], **kw: Any
+    ) -> list[Prediction]:
+        from hallmark.baselines.llm_agentic import verify_agentic_openai
+
+        kw.setdefault("model", "openai/gpt-5.1")
+        kw.setdefault("base_url", "https://openrouter.ai/api/v1")
+        kw.setdefault("api_key", os.environ.get("OPENROUTER_API_KEY"))
+        return verify_agentic_openai(entries, **kw)
+
+    register(
+        BaselineInfo(
+            name="llm_agentic_openrouter_gpt_5_1",
+            description=(
+                "Agentic GPT-5.1 via OpenRouter (openai/gpt-5.1) using the "
+                "OpenAI-compatible SDK. Drop-in for llm_agentic_openai without a "
+                "native OpenAI API key; GPT-5.1 counterpart of "
+                "llm_agentic_openrouter_claude_sonnet_4_6, used as the Stage 2 "
+                "diagnoser for cascade_db_diagnosis GPT-5.1 comparison runs."
+            ),
+            runner=_run_llm_agentic_openrouter_gpt_5_1,
+            pip_packages=["openai"],
+            requires_api_key=True,
+            is_free=False,
+            env_var="OPENROUTER_API_KEY",
+            confidence_type="probabilistic",
+        )
+    )
+
     # --- LLM: Agentic BTU-only (OpenAI) ---
     def _run_llm_agentic_btu_openai(entries: list[BlindEntry], **kw: Any) -> list[Prediction]:
         from hallmark.baselines.llm_agentic import verify_agentic_btu_openai

--- a/hallmark/baselines/registry.py
+++ b/hallmark/baselines/registry.py
@@ -644,40 +644,11 @@ def _register_builtins() -> None:
         )
     )
 
-    # --- LLM: Agentic OpenRouter GPT-5.1 ---
-    # Routes the OpenAI-compatible agentic harness through OpenRouter to use
-    # openai/gpt-5.1 without a native OpenAI API key. Drop-in replacement for
-    # llm_agentic_openai; the GPT-5.1 counterpart of
-    # llm_agentic_openrouter_claude_sonnet_4_6, intended as the Stage 2 diagnoser
-    # for cascade_db_diagnosis GPT-5.1 comparison runs under a lab OpenRouter key.
-    def _run_llm_agentic_openrouter_gpt_5_1(
-        entries: list[BlindEntry], **kw: Any
-    ) -> list[Prediction]:
-        from hallmark.baselines.llm_agentic import verify_agentic_openai
-
-        kw.setdefault("model", "openai/gpt-5.1")
-        kw.setdefault("base_url", "https://openrouter.ai/api/v1")
-        kw.setdefault("api_key", os.environ.get("OPENROUTER_API_KEY"))
-        return verify_agentic_openai(entries, **kw)
-
-    register(
-        BaselineInfo(
-            name="llm_agentic_openrouter_gpt_5_1",
-            description=(
-                "Agentic GPT-5.1 via OpenRouter (openai/gpt-5.1) using the "
-                "OpenAI-compatible SDK. Drop-in for llm_agentic_openai without a "
-                "native OpenAI API key; GPT-5.1 counterpart of "
-                "llm_agentic_openrouter_claude_sonnet_4_6, used as the Stage 2 "
-                "diagnoser for cascade_db_diagnosis GPT-5.1 comparison runs."
-            ),
-            runner=_run_llm_agentic_openrouter_gpt_5_1,
-            pip_packages=["openai"],
-            requires_api_key=True,
-            is_free=False,
-            env_var="OPENROUTER_API_KEY",
-            confidence_type="probabilistic",
-        )
-    )
+    # NOTE: ``llm_agentic_openrouter_gpt_5_1`` was removed once a native OpenAI key
+    # became available. It routed GPT-5.1 through OpenRouter as ``openai/gpt-5.1``,
+    # which made its runs inconsistent with every other GPT-5.1 experiment (all of
+    # which used the native endpoint and the bare ``gpt-5.1`` model id). Use
+    # ``llm_agentic_openai`` for GPT-5.1 Stage 2 diagnosis.
 
     # --- LLM: Agentic BTU-only (OpenAI) ---
     def _run_llm_agentic_btu_openai(entries: list[BlindEntry], **kw: Any) -> list[Prediction]:

--- a/tests/test_agentic_tools_retry_after.py
+++ b/tests/test_agentic_tools_retry_after.py
@@ -1,0 +1,69 @@
+"""Tests for Retry-After parsing and throttle detection in `_agentic_tools`.
+
+Covers the failure mode behind the 2026-07 cascade run, where 173 Semantic Scholar
+and 149 OpenAlex lookups were lost to HTTP 429: the servers stated when to return,
+and the client ignored them in favour of a fixed 1s/2s/4s schedule.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+
+from hallmark.baselines._agentic_tools import _parse_retry_after, _raise_for_throttle
+from hallmark.baselines._cache import RateLimitedError
+
+
+class _Resp:
+    """Minimal stand-in for an httpx.Response."""
+
+    def __init__(self, status_code: int, headers: dict[str, str] | None = None) -> None:
+        self.status_code = status_code
+        self.headers: dict[str, Any] = headers or {}
+
+
+class TestParseRetryAfter:
+    def test_delta_seconds(self):
+        assert _parse_retry_after("30") == 30.0
+
+    def test_http_date(self):
+        """RFC 9110 also permits an absolute date, which must resolve to a delay."""
+        future = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=42)
+        parsed = _parse_retry_after(future.strftime("%a, %d %b %Y %H:%M:%S GMT"))
+        assert parsed is not None
+        assert 30 <= parsed <= 45
+
+    def test_past_date_yields_none(self):
+        """An already-elapsed date means no wait is owed."""
+        past = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=60)
+        assert _parse_retry_after(past.strftime("%a, %d %b %Y %H:%M:%S GMT")) is None
+
+    @pytest.mark.parametrize("value", [None, "", "   ", "soon", "not-a-date"])
+    def test_unparseable_yields_none(self, value):
+        """Callers fall back to exponential backoff rather than crashing."""
+        assert _parse_retry_after(value) is None
+
+
+class TestRaiseForThrottle:
+    @pytest.mark.parametrize("code", [429, 503])
+    def test_throttle_codes_raise_with_delay(self, code):
+        with pytest.raises(RateLimitedError) as exc_info:
+            _raise_for_throttle(_Resp(code, {"Retry-After": "30"}), "TestSource")
+        assert exc_info.value.retry_after == 30.0
+
+    def test_throttle_without_header_still_raises(self):
+        """Still a rate limit, just with no instruction — retry_after is None."""
+        with pytest.raises(RateLimitedError) as exc_info:
+            _raise_for_throttle(_Resp(429), "TestSource")
+        assert exc_info.value.retry_after is None
+
+    @pytest.mark.parametrize("code", [200, 404, 500])
+    def test_non_throttle_codes_pass_through(self, code):
+        """Other statuses are left to the caller's own error handling."""
+        assert _raise_for_throttle(_Resp(code), "TestSource") is None
+
+    def test_none_response_passes_through(self):
+        """A missing response is not a throttle; the caller reports it separately."""
+        assert _raise_for_throttle(None, "TestSource") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import logging
+import time
+
 import pytest
 
-from hallmark.baselines._cache import cached_call, clear_cache, content_hash, retry_with_backoff
+from hallmark.baselines._cache import (
+    MAX_RETRY_AFTER_SECONDS,
+    NonRetryableError,
+    RateLimitedError,
+    cached_call,
+    clear_cache,
+    content_hash,
+    retry_with_backoff,
+)
 
 
 class TestContentHash:
@@ -78,6 +89,80 @@ class TestRetryWithBackoff:
 
         with pytest.raises(ValueError, match="permanent"):
             retry_with_backoff(always_fail, max_retries=2, base_delay=0.01)
+
+    def test_non_retryable_fails_on_first_attempt(self):
+        """Deterministic client-side faults must not be retried.
+
+        A decode failure recurs identically on every attempt, so the backoff
+        schedule only burns wall-clock and disguises a code defect as a flaky API.
+        """
+        attempts = 0
+
+        def deterministic_fault():
+            nonlocal attempts
+            attempts += 1
+            raise NonRetryableError("mislabelled response body")
+
+        with pytest.raises(NonRetryableError, match="mislabelled"):
+            retry_with_backoff(deterministic_fault, max_retries=3, base_delay=10.0)
+
+        assert attempts == 1, "NonRetryableError must not be retried"
+
+    def test_honours_server_retry_after(self, monkeypatch):
+        """A server-stated Retry-After replaces our exponential guess.
+
+        Retrying sooner than instructed is guaranteed to be refused again, which is
+        how a 7-second budget lost calls to endpoints asking for 30.
+        """
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+        def throttled():
+            raise RateLimitedError("HTTP 429", retry_after=30.0)
+
+        with pytest.raises(RateLimitedError):
+            retry_with_backoff(throttled, max_retries=3, base_delay=1.0)
+
+        assert slept == [30.0, 30.0, 30.0], "should wait as instructed, not 1/2/4"
+
+    def test_retry_after_is_capped(self, monkeypatch):
+        """An implausibly long Retry-After is capped so a run cannot stall."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+        def throttled():
+            raise RateLimitedError("HTTP 429", retry_after=3600.0)
+
+        with pytest.raises(RateLimitedError):
+            retry_with_backoff(throttled, max_retries=1, base_delay=1.0)
+
+        assert slept == [MAX_RETRY_AFTER_SECONDS]
+
+    def test_falls_back_to_exponential_without_header(self, monkeypatch):
+        """With no Retry-After, the original exponential schedule is unchanged."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+        def throttled():
+            raise RateLimitedError("HTTP 429", retry_after=None)
+
+        with pytest.raises(RateLimitedError):
+            retry_with_backoff(throttled, max_retries=3, base_delay=1.0)
+
+        assert slept == [1.0, 2.0, 4.0]
+
+    def test_non_retryable_logged_as_error(self, caplog):
+        """It is logged at ERROR, since it signals our bug rather than a sick upstream."""
+
+        def deterministic_fault():
+            raise NonRetryableError("mislabelled response body")
+
+        with caplog.at_level(logging.ERROR), pytest.raises(NonRetryableError):
+            retry_with_backoff(deterministic_fault, max_retries=3, base_delay=0.01)
+
+        assert [r for r in caplog.records if r.levelno == logging.ERROR], (
+            "expected an ERROR-level log record"
+        )
 
     def test_selective_exception_types(self):
         """Only retries on specified exception types."""

--- a/tests/test_http_cache.py
+++ b/tests/test_http_cache.py
@@ -119,6 +119,44 @@ def test_restores_httpx_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert httpx.get is original_get
 
 
+@pytest.mark.skipif(not _HAS_REQUESTS_CACHE, reason="requests-cache not installed")
+def test_gzip_labelled_body_is_readable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Regression: a body requests already decompressed must not be decompressed again.
+
+    OpenAlex answers with ``Content-Encoding: gzip``; ``requests`` transparently
+    decompresses the payload but leaves the header in place.  Forwarding that stale
+    header onto an ``httpx.Response`` made httpx decompress plain text, raising
+    ``Error -3 while decompressing data: incorrect header check`` — the failure
+    behind 43 lost lookups in the 2026-07 cascade run.
+    """
+    import requests_cache
+
+    def gzip_labelled_send(self: Any, request: Any, **kwargs: Any) -> Any:
+        from requests import Response
+
+        resp = Response()
+        resp.status_code = 200
+        # Body as requests hands it over: already decompressed.
+        resp._content = b'{"meta": {"count": 8}}'
+        # Headers as the server sent them: still describing the compressed bytes.
+        resp.headers["Content-Encoding"] = "gzip"
+        resp.headers["Content-Length"] = "9999"
+        resp.headers["Content-Type"] = "application/json"
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+    monkeypatch.setattr(requests_cache.CachedSession, "send", gzip_labelled_send)
+
+    with http_cache(tmp_path / "gzip.sqlite"):
+        resp = httpx.get("https://api.openalex.org/works?query=x")
+
+    assert resp.json() == {"meta": {"count": 8}}
+    # The stale wire-format headers must not survive onto the adapted response.
+    assert "content-encoding" not in resp.headers
+    assert resp.headers["content-type"] == "application/json"
+
+
 def test_missing_optional_dependency_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """If requests-cache is missing, calling http_cache with a path raises ImportError."""
     import builtins


### PR DESCRIPTION
Regarding cascade stage 2 with gpt-5.1
- DB lookup failure fix
- checkpoint dir fix
- Tests for DB lookup solutions
- Openrouter wrapper was added but deleted (to run with native API endpoint)
- Semantic Scholar, Open AI, OpenRouter API key