### PR TITLE
fix(schema): record doi_resolves as None when no DOI is present

### DIFF
--- a/hallmark/dataset/generators/tier2.py
+++ b/hallmark/dataset/generators/tier2.py
@@ -213,7 +213,8 @@ def generate_merged_citation(
         f"authors from '{entry_a.bibtex_key}', title from '{entry_b.bibtex_key}'"
     )
     subtests = dict(EXPECTED_SUBTESTS[HallucinationType.MERGED_CITATION])
-    subtests["doi_resolves"] = entry_b.doi is not None
+    # N/A when the donor entry has no DOI — absence is not a failed resolution.
+    subtests["doi_resolves"] = True if entry_b.doi is not None else None
     new_entry.subtests = subtests
     new_entry.bibtex_key = f"merged_{entry_b.bibtex_key}"
     return new_entry
@@ -273,7 +274,8 @@ def generate_partial_author_list(
         f"{len(new_entry.fields.get('author', '').split(' and '))}"
     )
     subtests = dict(EXPECTED_SUBTESTS[HallucinationType.PARTIAL_AUTHOR_LIST])
-    subtests["doi_resolves"] = entry.doi is not None
+    # N/A when the source entry has no DOI — absence is not a failed resolution.
+    subtests["doi_resolves"] = True if entry.doi is not None else None
     new_entry.subtests = subtests
     new_entry.bibtex_key = f"partial_authors_{new_entry.bibtex_key}"
     return new_entry

--- a/hallmark/dataset/schema.py
+++ b/hallmark/dataset/schema.py
@@ -218,7 +218,25 @@ STRESS_TEST_TYPES: set[HallucinationType] = {
 MAIN_TYPES: set[HallucinationType] = set(HallucinationType) - STRESS_TEST_TYPES
 
 
-# Standard sub-test names
+# Standard sub-test names.
+#
+# Scoping rule (three-valued, entry-relative)
+# -------------------------------------------
+# Every sub-test is evaluated **against the fields actually present in this
+# entry**, never against the citation as a whole:
+#
+#   True   the check was performed and passed
+#   False  the check was performed and FAILED
+#   None   the check is not applicable — the field it inspects is absent
+#
+# So ``doi_resolves`` answers "did *this entry's* ``doi`` field resolve?", not
+# "does this reference have any resolvable identifier?". An entry with no
+# ``doi`` field is ``None`` (nothing to resolve), never ``False``. The same
+# holds for every other sub-test: absence of the inspected field is ``None``.
+#
+# Rationale: baselines only ever see ``BlindEntry.fields``, so a ``False`` on a
+# field that is not there asks a tool to detect something it cannot observe.
+# Enforced by the structural check in ``scripts/verify_subtests.py``.
 SUBTEST_NAMES = [
     "doi_resolves",
     "title_exists",

--- a/scripts/scrape_crossdomain.py
+++ b/scripts/scrape_crossdomain.py
@@ -399,20 +399,48 @@ def scrape_cs_non_ml(target: int, years: list[int]) -> list[BenchmarkEntry]:
 
 
 def verify_doi_resolution(entries: list[BenchmarkEntry], rate: float = 0.3) -> list[BenchmarkEntry]:
-    """Update ``doi_resolves`` subtest by hitting CrossRef. Drops nothing."""
+    """Update ``doi_resolves`` subtest by hitting CrossRef. Drops nothing.
+
+    Three-valued, per the scoping rule beside ``SUBTEST_NAMES`` in
+    ``hallmark.dataset.schema``:
+
+    * ``True``  — the DOI was looked up and resolved.
+    * ``False`` — the DOI was looked up and did NOT resolve.
+    * ``None``  — not applicable (entry carries no DOI) or not verifiable
+      (the lookup itself failed).
+
+    A transient CrossRef error is *not* evidence that a DOI is bad, so it must
+    not be recorded as ``False``: that would bake a network blip into a
+    released split as permanent ground truth. Unverified entries are counted
+    and logged so a degraded run is visible instead of silently shipping.
+    """
     cr = CrossRefClient(rate_limit=rate)
+    unverified = 0
     for i, e in enumerate(entries):
         doi = e.fields.get("doi")
         if not doi:
-            e.subtests["doi_resolves"] = False
+            # No DOI to resolve — not applicable, not a failure.
+            e.subtests["doi_resolves"] = None
             continue
         try:
-            ok = cr.verify_doi(doi)
-        except Exception:
-            ok = False
-        e.subtests["doi_resolves"] = ok
+            e.subtests["doi_resolves"] = cr.verify_doi(doi)
+        except Exception as exc:
+            logger.warning(
+                "DOI lookup failed for %s (%s); leaving doi_resolves=None",
+                e.bibtex_key,
+                exc,
+            )
+            e.subtests["doi_resolves"] = None
+            unverified += 1
         if (i + 1) % 25 == 0:
             logger.info("verified %d/%d", i + 1, len(entries))
+    if unverified:
+        logger.warning(
+            "%d/%d entries left unverified due to lookup errors — "
+            "re-run before treating this pass as ground truth",
+            unverified,
+            len(entries),
+        )
     return entries
 
 

--- a/scripts/verify_subtests.py
+++ b/scripts/verify_subtests.py
@@ -99,9 +99,18 @@ class ScanReport:
         default_factory=lambda: defaultdict(Counter)
     )
 
+    #: Structural violations (field-scoped sub-test False with the field absent).
+    #: Tracked separately from ``mismatches`` so the truth-table agreement rate
+    #: and its ratcheted bound keep their original meaning.
+    structural: list[Mismatch] = field(default_factory=list)
+
     @property
     def num_mismatches(self) -> int:
         return len(self.mismatches)
+
+    @property
+    def num_structural(self) -> int:
+        return len(self.structural)
 
     @property
     def agreement(self) -> float:
@@ -119,6 +128,48 @@ def _expected_subtests_for(entry: dict) -> dict[str, bool | None] | None:
     if enum is None:
         return None
     return EXPECTED_SUBTESTS[enum]
+
+
+#: Sub-tests that inspect a specific BibTeX field. When that field is absent
+#: from the entry, the check is not applicable and the sub-test MUST be None —
+#: never False. See the scoping rule beside ``SUBTEST_NAMES`` in
+#: ``hallmark.dataset.schema``.
+FIELD_SCOPED_SUBTESTS: dict[str, str] = {
+    "doi_resolves": "doi",
+}
+
+
+def verify_entry_structural(entry: dict) -> list[Mismatch]:
+    """Return structural sub-test violations for a single entry.
+
+    This check is independent of ``EXPECTED_SUBTESTS``. It exists because the
+    truth-table pass skips any sub-test whose expected value is ``None``
+    ("depends on the source entry") — which is exactly the case for
+    ``doi_resolves`` on most types, so a ``False`` on a DOI-less entry slips
+    through unnoticed.
+
+    A violation is recorded when a field-scoped sub-test is ``False`` while the
+    field it inspects is absent from ``entry["fields"]``: the check cannot have
+    been performed, so the correct value is ``None``.
+    """
+    subtests = entry.get("subtests") or {}
+    fields = entry.get("fields") or {}
+    split = entry.get("_split", "")
+    out: list[Mismatch] = []
+    for name, field_name in FIELD_SCOPED_SUBTESTS.items():
+        if subtests.get(name) is False and not fields.get(field_name):
+            out.append(
+                Mismatch(
+                    split=split,
+                    bibtex_key=entry.get("bibtex_key", ""),
+                    label=entry.get("label", ""),
+                    hallucination_type=entry.get("hallucination_type"),
+                    subtest=name,
+                    assigned=False,
+                    expected=None,
+                )
+            )
+    return out
 
 
 def verify_entry_subtests(entry: dict) -> list[Mismatch]:
@@ -182,6 +233,10 @@ def scan_splits(splits: dict[str, Path] | None = None) -> ScanReport:
                 if _is_canary(entry) or not (entry.get("subtests") or {}):
                     report.skipped_entries += 1
                     continue
+                # Structural check first: it is independent of the truth table,
+                # so it still applies to unknown types and None-expected fields.
+                entry["_split"] = split_name
+                report.structural.extend(verify_entry_structural(entry))
                 expected = _expected_subtests_for(entry)
                 if expected is None:
                     report.unknown_types[entry.get("hallucination_type")] += 1
@@ -225,6 +280,17 @@ def print_report(report: ScanReport) -> None:
         f"Overall agreement: {report.agreement:.1f}% "
         f"({report.num_mismatches}/{report.total_checks} sub-test checks mismatch the truth table)."
     )
+
+    if report.structural:
+        by_split: Counter = Counter(m.split for m in report.structural)
+        by_subtest: Counter = Counter(m.subtest for m in report.structural)
+        print(
+            f"\nSTRUCTURAL violations: {report.num_structural} "
+            "(field-scoped sub-test is False but the field it inspects is absent; "
+            "the correct value is None -- see the scoping rule in hallmark.dataset.schema)."
+        )
+        print(f"  by sub-test: {dict(by_subtest)}")
+        print(f"  by split   : {dict(by_split)}")
 
     if report.unknown_types:
         print("\nEntries with unknown hallucination_type (not in taxonomy):")
@@ -277,6 +343,7 @@ def main() -> int:
             "skipped_entries": report.skipped_entries,
             "total_checks": report.total_checks,
             "num_mismatches": report.num_mismatches,
+            "num_structural": report.num_structural,
             "agreement_pct": round(report.agreement, 4),
             "per_split": {s: dict(c) for s, c in report.per_split.items()},
             "per_type_subtest": {
@@ -284,6 +351,7 @@ def main() -> int:
             },
             "unknown_types": dict(report.unknown_types),
             "mismatches": [m.as_dict() for m in report.mismatches],
+            "structural": [m.as_dict() for m in report.structural],
         }
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     else:


### PR DESCRIPTION
Issue 1 -- DOI issue

merged_citation and partial_author_list in tier2.py wrote False for entries with no DOI, instead of NULL
Cause: entry.doi is not None returns a boolean, no option of NULL
Effect: some entries looked multi-defect but are actually single-defect
**Fixed**, lines in tier2.py ; now it has NULL option

Issue 2 -- DOI issue (from real_world_incidents)

Cause: data were labeled doi_resolves: False for fabricated papers with no DOI, reasoning "the paper doesn't exist, so nothing resolves". Also affects entries in test_crossdomain from scrape_crossdomain.py
**Fixed**, revised verify_subtest.py to detect these
**Fixed**, corrected inaccurate DOI record in scrape_crossdomain.py
- NULL for missing DOI
- NULL for lookup errors (returns unverified entries from CrossRef) -- Never happened

What's next: Data fix
@rpatrik96 