### PR TITLE
fix(baselines): a batch with no database evidence is a broken lookup path, not a fabricated bibliography

### DIFF
--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -25,6 +25,14 @@ as before (the precomputed reference results are unaffected):
 - ``p_valid`` (float in [0, 1]): explicit P(entry as cited is genuine) — the
   value to threshold on.  When present it replaces the older realness
   inversion heuristic for deriving ``Prediction.confidence``.
+
+Every invocation is scored by a batch-level sanity check (``assess_batch_health``)
+before the results are handed back.  ``not_found`` is evidence of fabrication only
+when the sources were actually reached, so a batch where most entries come back
+``not_found`` — or carry an explicit transport-failure status — is reported as a
+broken lookup path rather than a bibliography of invented papers.  Callers that
+persist results should gate on ``BatchHealth.suspected_transport_failure`` via
+``run_bibtex_check_with_health`` and refuse to checkpoint a batch that trips it.
 """
 
 from __future__ import annotations
@@ -34,6 +42,8 @@ import logging
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from hallmark.baselines._cache import redact_command
@@ -56,6 +66,8 @@ STATUS_TO_LABEL: dict[str, str] = {
     "partial_match": "HALLUCINATED",
     "hallucinated": "HALLUCINATED",
     "api_error": "VALID",  # Conservative: don't flag on errors
+    "network_error": "VALID",  # Lookup never reached a source: abstention, not evidence
+    "coverage_incomplete": "VALID",  # Sources throttled/errored: abstention, not evidence
     # bibtex-updater >=1.2.0 statuses
     "unconfirmed": "VALID",  # Abstention (could-not-verify): conservative VALID
     "given_name_substitution": "HALLUCINATED",  # Co-author given name is a different person
@@ -100,6 +112,8 @@ STATUS_TO_CONFIDENCE: dict[str, float] = {
     "partial_match": 0.70,
     "hallucinated": 0.90,
     "api_error": 0.30,
+    "network_error": 0.30,
+    "coverage_incomplete": 0.45,
     "unconfirmed": 0.45,
     "given_name_substitution": 0.75,
     "arxiv_id_mismatch": 0.90,
@@ -124,6 +138,154 @@ STATUS_TO_CONFIDENCE: dict[str, float] = {
     "working_paper_not_found": 0.70,
     "skipped": 0.50,
 }
+
+
+# ---------------------------------------------------------------------------
+# Batch-level sanity check
+# ---------------------------------------------------------------------------
+
+# Statuses that say the lookup never reached a source, as opposed to reaching
+# the sources and being told nothing is there.  ``api_error`` is the tool's
+# long-standing catch-all; ``network_error`` is carried here so an upgraded tool
+# that reports transport failures under their own status is handled the same way.
+TRANSPORT_FAILURE_STATUSES: frozenset[str] = frozenset({"api_error", "network_error"})
+
+# Statuses that say the sources answered but the sweep was not exhaustive — a
+# source was throttled or errored out, so the absence of a record proves nothing.
+# ``coverage_incomplete`` is currently a boolean flag on a ``not_found`` record;
+# it is accepted as a status name here so the check keeps working if the tool
+# promotes it to one.
+COVERAGE_INCOMPLETE_STATUSES: frozenset[str] = frozenset({"coverage_incomplete"})
+
+# Share of a batch that may come back without database evidence before we stop
+# believing the batch.  Healthy HALLMARK runs sit at ~52% ``verified`` and 1-3%
+# ``not_found``.  On 2026-09-02 a wifi outage made every source lookup fail DNS
+# resolution and bibtex-check returned ``not_found`` for 2,500 consecutive
+# references; the poisoned chunks ran 85-98% ``not_found``.  30% is an order of
+# magnitude above the healthy ceiling and far below the observed poisoning, so it
+# separates the two regimes with room on both sides — a genuinely
+# fabrication-heavy bibliography stays under it, and no partial outage that
+# matters lands beneath it.
+NOT_FOUND_SHARE_THRESHOLD: float = 0.30
+
+# Below this many entries the share is too noisy to act on.  At the healthy 3%
+# base rate, 6 of 20 entries returning ``not_found`` has probability ~2e-5, so 20
+# is the smallest batch where crossing 30% is decisive rather than unlucky.
+MIN_BATCH_FOR_HEALTH_CHECK: int = 20
+
+
+@dataclass(frozen=True)
+class BatchHealth:
+    """Batch-level sanity signal for one ``bibtex-check`` invocation.
+
+    ``not_found`` means "every source was asked and none had this paper", which
+    is only evidence of fabrication when the sources were actually reached.  A
+    batch where most entries carry ``not_found`` or a transport-failure status is
+    far more likely to be a broken network path than a bibliography of invented
+    papers, so a caller that persists results should refuse to checkpoint it and
+    re-run once connectivity is back.
+
+    The ``"missing"`` sentinel is deliberately not counted here: it means
+    bibtex-check produced no record at all (usually a timeout), which
+    ``_run_bibtex_check_subprocess`` already logs on its own terms.
+
+    Attributes:
+        total: Number of entries in the batch.
+        not_found: Entries whose status was ``not_found``.
+        transport_error: Entries whose status was in
+            ``TRANSPORT_FAILURE_STATUSES``.
+        coverage_incomplete: Entries whose status was in
+            ``COVERAGE_INCOMPLETE_STATUSES`` (sources reached but throttled or
+            partially errored).
+        threshold: No-evidence share above which the batch is suspect.
+        min_batch_size: Smallest batch the share is evaluated on.
+    """
+
+    total: int
+    not_found: int
+    transport_error: int
+    coverage_incomplete: int = 0
+    threshold: float = NOT_FOUND_SHARE_THRESHOLD
+    min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK
+
+    @property
+    def not_found_share(self) -> float:
+        """Fraction of the batch that came back ``not_found``."""
+        return self.not_found / self.total if self.total else 0.0
+
+    @property
+    def transport_error_share(self) -> float:
+        """Fraction of the batch that reported an explicit transport failure."""
+        return self.transport_error / self.total if self.total else 0.0
+
+    @property
+    def no_evidence(self) -> int:
+        """Entries the batch produced no usable database evidence for."""
+        return self.not_found + self.transport_error + self.coverage_incomplete
+
+    @property
+    def no_evidence_share(self) -> float:
+        """Fraction of the batch for which no source returned a usable verdict.
+
+        Combines ``not_found``, transport failures and coverage-incomplete
+        abstentions so the check reads the same signal whether or not the
+        upstream tool has been upgraded to report failed lookups under their own
+        status.
+        """
+        return self.no_evidence / self.total if self.total else 0.0
+
+    @property
+    def suspected_transport_failure(self) -> bool:
+        """True when the batch looks like a broken lookup path, not a bad bibliography.
+
+        This is the flag to gate checkpointing on.
+        """
+        return self.total >= self.min_batch_size and self.no_evidence_share > self.threshold
+
+    def warning_message(self) -> str:
+        """Operator-facing description of why the batch is not usable."""
+        return (
+            f"bibtex-check returned no database evidence for "
+            f"{self.no_evidence}/{self.total} entries "
+            f"({self.no_evidence_share:.1%}: {self.not_found} not_found, "
+            f"{self.transport_error} transport errors, "
+            f"{self.coverage_incomplete} coverage-incomplete), above the "
+            f"{self.threshold:.0%} batch threshold. Healthy runs sit at 1-3% "
+            f"not_found, so a share this high is almost always a broken lookup "
+            f"path — a DNS, network or proxy outage, or sustained throttling — "
+            f"rather than a bibliography of invented papers. Treat these "
+            f"predictions as unusable: do not checkpoint this batch, and re-run "
+            f"once the lookup path is healthy."
+        )
+
+
+def assess_batch_health(
+    statuses: Iterable[str],
+    *,
+    threshold: float = NOT_FOUND_SHARE_THRESHOLD,
+    min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK,
+) -> BatchHealth:
+    """Score one batch of bibtex-check statuses for transport-failure poisoning.
+
+    Args:
+        statuses: Raw per-entry status strings, e.g. the values of the dict
+            returned by ``run_bibtex_check_with_status``.
+        threshold: No-evidence share above which the batch is suspect.
+        min_batch_size: Smallest batch on which the share is evaluated.
+
+    Returns:
+        A ``BatchHealth`` record; ``suspected_transport_failure`` is the flag a
+        caller gates checkpointing on.
+    """
+    status_list = list(statuses)
+    return BatchHealth(
+        total=len(status_list),
+        not_found=sum(1 for s in status_list if s == "not_found"),
+        transport_error=sum(1 for s in status_list if s in TRANSPORT_FAILURE_STATUSES),
+        coverage_incomplete=sum(1 for s in status_list if s in COVERAGE_INCOMPLETE_STATUSES),
+        threshold=threshold,
+        min_batch_size=min_batch_size,
+    )
 
 
 def run_bibtex_check(
@@ -183,11 +345,30 @@ def run_bibtex_check_with_status(
     Values are the raw ``status`` field from the bibtex-check JSONL output, e.g.:
 
     - ``"verified"`` — found in at least one academic database and metadata matches
-    - ``"not_found"`` — no database returned a matching record.  The same status
-      string also covers coverage-incomplete lookups (post-1.2.0
-      ``coverage_incomplete`` records, where sources errored / were throttled);
-      the prediction for those is an abstention-style VALID, and downstream
-      cascades should keep routing ``"not_found"`` as uncertain.
+    - ``"not_found"`` — **an exhaustive miss, and a positive claim about the
+      lookup**: every source consulted completed successfully and returned no
+      matching record.  A transport failure must NOT be reported under this
+      status.  If any source failed for a technical reason — DNS resolution,
+      connection refused or reset, TLS failure, timeout, 5xx, or a 429 that ended
+      the attempt without an answer — the entry is an abstention, not an
+      exhaustive miss, even when the sources that did answer found nothing.
+      Conflating the two is what let a 2026-09-02 wifi outage produce
+      ``not_found`` for 2,500 consecutive references with zero database evidence
+      behind any of them.  Older tool builds do carry ``coverage_incomplete`` on
+      such records; the wrapper reads that flag and downgrades the prediction to
+      an abstention-style VALID, and downstream cascades keep routing
+      ``"not_found"`` to Stage 2 as uncertain either way.  ``assess_batch_health``
+      is the batch-level backstop for builds that report neither.
+    - ``"network_error"`` — the lookup never reached a source (DNS, connection,
+      TLS, or timeout).  An abstention: conservative VALID, routed to Stage 2,
+      never HALLUCINATED.  Note that an HTTP error response is not this — a 4xx
+      or 5xx proves the network came up — so a throttling 429 belongs under
+      ``coverage_incomplete``, not here.
+    - ``"coverage_incomplete"`` — the sources answered but the sweep was not
+      exhaustive (a source was throttled or errored out).  An abstention on the
+      same terms as ``network_error``.  In current tool builds this arrives as a
+      boolean flag on a ``not_found`` record rather than as a status of its own;
+      both shapes are handled.
     - ``"title_mismatch"`` / ``"author_mismatch"`` / ``"year_mismatch"`` /
       ``"venue_mismatch"`` — found but a field differs from the claimed value
     - ``"nonexistent_venue"`` — claimed venue unknown to the DBLP/OpenAlex venue
@@ -228,6 +409,11 @@ def run_bibtex_check_with_status(
         A 2-tuple ``(predictions, status_dict)`` where ``status_dict`` maps every
         input ``bibtex_key`` to a status string.  The dict is guaranteed to contain
         an entry for every key in ``entries``.
+
+    The batch is scored by ``assess_batch_health`` before returning and a
+    poisoned batch is logged at WARNING level.  Callers that persist results
+    should use ``run_bibtex_check_with_health`` instead and gate checkpointing on
+    ``BatchHealth.suspected_transport_failure``.
     """
     all_keys: list[str] = [e.bibtex_key for e in entries]
 
@@ -295,7 +481,54 @@ def run_bibtex_check_with_status(
         else:
             status_dict[key] = tool_key_to_status.get(key, "missing")
 
+    # Step 7: Batch-level sanity check. A batch that is mostly no-evidence is a
+    # broken lookup path, not a bibliography of invented papers — say so loudly
+    # so an operator watching the log can kill the run before it burns Stage 2
+    # budget on entries no database was ever asked about.
+    health = assess_batch_health(status_dict.values())
+    if health.suspected_transport_failure:
+        logger.warning(health.warning_message())
+
     return final_predictions, status_dict
+
+
+def run_bibtex_check_with_health(
+    entries: list[BlindEntry],
+    extra_args: list[str] | None = None,
+    timeout: float = 7200.0,
+    rate_limit: int = 120,
+    academic_only: bool = True,
+    skip_prescreening: bool = False,
+    **_kw: object,
+) -> tuple[list[Prediction], dict[str, str], BatchHealth]:
+    """Run bibtex-check and return predictions, statuses, and the batch health signal.
+
+    Same behaviour as ``run_bibtex_check_with_status`` with the batch-level sanity
+    check returned rather than only logged.  Use this from anything that persists
+    results: when ``BatchHealth.suspected_transport_failure`` is True the batch
+    carries no database evidence and must not be checkpointed, since a resumed run
+    would then treat the poisoned verdicts as settled.
+
+    Args:
+        entries: Benchmark entries to verify.
+        extra_args: Additional CLI arguments for bibtex-check.
+        timeout: Timeout in seconds (default: 7200).
+        rate_limit: API requests per minute (default: 120).
+        academic_only: Skip web/book/working-paper checks (default: True).
+        skip_prescreening: Skip pre-screening checks (default: False).
+
+    Returns:
+        A 3-tuple ``(predictions, status_dict, health)``.
+    """
+    predictions, status_dict = run_bibtex_check_with_status(
+        entries,
+        extra_args=extra_args,
+        timeout=timeout,
+        rate_limit=rate_limit,
+        academic_only=academic_only,
+        skip_prescreening=skip_prescreening,
+    )
+    return predictions, status_dict, assess_batch_health(status_dict.values())
 
 
 def _run_bibtex_check_subprocess(

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -287,12 +287,22 @@ def run_cascade_with_health(
     existed, and they are not recomputed by it: they are frozen files in
     ``data/v1.2/baseline_results/`` that CI validates by checksum rather than
     re-running.  The guard cannot alter them.  It is also inert on a healthy
-    batch by construction — ``suspected_transport_failure`` is False whenever the
-    no-evidence share stays under the threshold, and the frozen conservative runs
-    bound that share below it (``cascade_breakdown_stats``: 23.8% of dev_public
-    and 26.7% of test_public deferred to Stage 2 at all, and the no-evidence
-    statuses are a subset of the deferred).  Only a future run on degraded input
-    behaves differently.
+    batch by construction: ``suspected_transport_failure`` is False whenever the
+    no-evidence share stays under the threshold, and the no-evidence statuses are
+    a subset of what defers to Stage 2, so the frozen conservative runs'
+    ``cascade_breakdown_stats`` bound the share from above.  For dev_public
+    (266/1119 = 23.8% deferred) and test_public (222/831 = 26.7%) the bound is
+    below the 30% threshold, so those splits' aggressive numbers cannot change on
+    a re-run.
+
+    stress_test defers 53/121 = 43.8%, which is an upper bound only: deferrals
+    also include ``unconfirmed``, ``partial_match``, ``skipped`` and ``missing``,
+    none of which count toward the no-evidence share.  The raw status dump needed
+    to compute the actual share is not in the repo:
+    ``bibtexupdater_raw_dev_public.jsonl`` is an unfetched git-lfs pointer and
+    there is no stress_test raw dump at all.  A future re-run of the aggressive
+    stress_test split is therefore the one place this guard could in principle
+    produce different numbers; the frozen file is untouched regardless.
     """
     if not entries:
         return [], assess_batch_health([])

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -5,7 +5,11 @@ Stage 1: ``bibtexupdater`` (CrossRef / DBLP / Semantic Scholar lookup).
 - Definite mismatch statuses (``doi_not_found``, ``venue_mismatch``, etc.) →
   emit HALLUCINATED with a status-derived ``predicted_hallucination_type``.
 - Ambiguous statuses (``not_found``, ``partial_match``, ``api_error``,
-  ``skipped``, ``missing``) → defer to Stage 2.
+  ``network_error``, ``coverage_incomplete``, ``skipped``, ``missing``) → defer
+  to Stage 2.
+- An unmapped status also defers to Stage 2.  This is deliberate, not incidental:
+  a status the wrapper has never seen carries no evidence either way, and the only
+  safe direction to fail is towards a second opinion.
 
 Stage 2: a configurable LLM diagnoser (default ``llm_agentic_anthropic``) is
 asked to decide VALID vs HALLUCINATED and, when HALLUCINATED, to classify the
@@ -16,6 +20,12 @@ HALLUCINATED with type ``plausible_fabrication`` and confidence 0.55. This
 implements the "treat DB lookups as gold standard" stance — at the cost of
 inflated FPR on legitimately-but-not-yet-indexed entries, which the dual-mode
 evaluation surfaces as the DB-indexing-lag tax.
+
+Stage 1 statuses are also scored as a batch: ``run_cascade_with_health`` returns
+the ``BatchHealth`` record for the bibtex-check invocation so a caller can refuse
+to checkpoint a run whose Stage 1 produced no database evidence at all.  That is
+the shape a transport outage takes, and without the check the cascade forwards
+the whole batch to an expensive Stage 2 that has nothing to work from.
 """
 
 from __future__ import annotations
@@ -24,7 +34,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hallmark.baselines.bibtexupdater import run_bibtex_check_with_status
+from hallmark.baselines.bibtexupdater import (
+    BatchHealth,
+    assess_batch_health,
+    run_bibtex_check_with_status,
+)
 from hallmark.dataset.schema import BlindEntry, Prediction
 
 logger = logging.getLogger(__name__)
@@ -52,7 +66,8 @@ STATUS_TO_TYPE: dict[str, str] = {
     # Post-1.2.0 positive-evidence statuses — decided problems, never Stage 2
     "nonexistent_venue": "nonexistent_venue",  # venue unknown to DBLP/OpenAlex registries
     "unpublished_at_claimed_venue": "preprint_as_published",  # real paper, not at cited venue
-    # not_found / unconfirmed / partial_match / api_error / skipped / missing → Stage 2
+    # not_found / unconfirmed / partial_match / api_error / network_error /
+    # coverage_incomplete / skipped / missing → Stage 2 (see ROUTE_TO_STAGE2)
 }
 
 # Statuses that Stage 1 treats as definitive VALID.
@@ -67,19 +82,30 @@ STAGE1_VERIFIED: set[str] = {
 
 # Statuses routed to Stage 2 for diagnosis.
 ROUTE_TO_STAGE2: set[str] = {
-    # ``not_found`` covers both clean exhaustive misses and coverage-incomplete
-    # lookups (post-1.2.0 ``coverage_incomplete`` — sources errored / were
-    # throttled); both shapes are uncertain and defer to Stage 2.
+    # ``not_found`` is meant to be an exhaustive miss — every source consulted
+    # completed and returned nothing — but the cascade never treats it as
+    # evidence of fabrication on its own, because older tool builds also emit it
+    # for lookups that failed in transit. Uncertain either way: defer to Stage 2.
     "not_found",
     "partial_match",
     "api_error",
     "skipped",
     "missing",
+    # Transport and coverage failures: the lookup never completed, so the entry
+    # carries no evidence in either direction.  These must never reach
+    # ``STATUS_TO_TYPE`` — a failed request is not a fabricated reference.
+    "network_error",
+    "coverage_incomplete",
     # bibtex-updater >=1.2.0 abstention statuses (could-not-verify)
     "unconfirmed",
     "strict_warn_preprint_year",
     "strict_warn_cnv",
 }
+
+
+# Unmapped statuses seen in this process, so a drifted tool vocabulary is
+# reported once rather than once per entry.
+_WARNED_UNMAPPED_STATUSES: set[str] = set()
 
 
 def _stage1_predict(
@@ -141,9 +167,25 @@ def _stage1_predict(
     if status in ROUTE_TO_STAGE2:
         return None
 
-    logger.debug(
-        "cascade: unmapped status %r for %s — routing to Stage 2", status, raw_pred.bibtex_key
-    )
+    # Deliberate open-world default: a status the wrapper has never seen is
+    # routed to Stage 2 rather than mapped to a verdict here.  Failing towards a
+    # second opinion is the only safe direction — the alternative is inventing
+    # evidence from an unknown string.  An unmapped status also means the tool's
+    # vocabulary has drifted ahead of ``STATUS_TO_TYPE`` / ``ROUTE_TO_STAGE2``,
+    # so the first sighting is a WARNING; the rest stay at DEBUG so a whole batch
+    # of them cannot drown out the batch-health warning.
+    if status not in _WARNED_UNMAPPED_STATUSES:
+        _WARNED_UNMAPPED_STATUSES.add(status)
+        logger.warning(
+            "cascade: unmapped bibtex-check status %r (first seen on %s) — routing "
+            "to Stage 2, never HALLUCINATED; add it to the status maps",
+            status,
+            raw_pred.bibtex_key,
+        )
+    else:
+        logger.debug(
+            "cascade: unmapped status %r for %s — routing to Stage 2", status, raw_pred.bibtex_key
+        )
     return None
 
 
@@ -186,6 +228,30 @@ def run_cascade(
     stage2_kwargs: dict[str, Any] | None = None,
     **stage1_kwargs: Any,
 ) -> list[Prediction]:
+    """Run the DB-first cascade and return predictions only.
+
+    Thin wrapper over ``run_cascade_with_health`` for callers that do not persist
+    results; see that function for the arguments and for the batch-health signal
+    a checkpointing caller needs.
+    """
+    predictions, _ = run_cascade_with_health(
+        entries,
+        stage2_baseline=stage2_baseline,
+        aggressive=aggressive,
+        stage2_kwargs=stage2_kwargs,
+        **stage1_kwargs,
+    )
+    return predictions
+
+
+def run_cascade_with_health(
+    entries: list[BlindEntry],
+    *,
+    stage2_baseline: str = "llm_agentic_anthropic",
+    aggressive: bool = False,
+    stage2_kwargs: dict[str, Any] | None = None,
+    **stage1_kwargs: Any,
+) -> tuple[list[Prediction], BatchHealth]:
     """Run the DB-first cascade with hallucination-mode diagnosis.
 
     Args:
@@ -199,9 +265,15 @@ def run_cascade(
             stance from the reviewer feedback.
         stage2_kwargs: kwargs forwarded to the Stage 2 baseline runner.
         **stage1_kwargs: forwarded to ``run_bibtex_check_with_status``.
+
+    Returns:
+        A 2-tuple ``(predictions, health)``. ``health`` scores the Stage 1 status
+        map: when ``health.suspected_transport_failure`` is True the Stage 1
+        lookups produced no database evidence, every Stage 2 verdict in the batch
+        rests on nothing, and the caller must not checkpoint the results.
     """
     if not entries:
-        return []
+        return [], assess_batch_health([])
 
     # The harness injects ``checkpoint_dir`` for baselines that support
     # per-entry resume. Stage 1 (bibtex-check subprocess) has no checkpoint
@@ -216,6 +288,18 @@ def run_cascade(
 
     stage1_preds, status_map = run_bibtex_check_with_status(entries, **stage1_kwargs)
     pred_by_key = {p.bibtex_key: p for p in stage1_preds}
+
+    # Computed from the status map rather than inside the wrapper so the signal
+    # survives whichever Stage 1 path produced it.
+    health = assess_batch_health(status_map.values())
+    if health.suspected_transport_failure:
+        logger.warning(
+            "cascade Stage 1 produced no database evidence for %d/%d entries — "
+            "every Stage 2 verdict in this batch rests on nothing. Do not "
+            "checkpoint these results.",
+            health.no_evidence,
+            health.total,
+        )
 
     final: dict[str, Prediction] = {}
     deferred: list[BlindEntry] = []
@@ -273,7 +357,7 @@ def run_cascade(
             if pred.cascade_stage in {"stage2_diagnosis"}:
                 final[key] = _aggressive_fallback(pred)
 
-    return [final[entry.bibtex_key] for entry in entries]
+    return [final[entry.bibtex_key] for entry in entries], health
 
 
 def _run_stage2(

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -19,7 +19,10 @@ Aggressive mode: any entry that remains UNCERTAIN after Stage 2 is forced to
 HALLUCINATED with type ``plausible_fabrication`` and confidence 0.55. This
 implements the "treat DB lookups as gold standard" stance — at the cost of
 inflated FPR on legitimately-but-not-yet-indexed entries, which the dual-mode
-evaluation surfaces as the DB-indexing-lag tax.
+evaluation surfaces as the DB-indexing-lag tax.  The promotion is suppressed on a
+batch whose Stage 1 produced no database evidence: during an outage there is no
+gold standard to treat as one, and promoting the residue would manufacture mass
+fabrication verdicts out of failed requests.
 
 Stage 1 statuses are also scored as a batch: ``run_cascade_with_health`` returns
 the ``BatchHealth`` record for the bibtex-check invocation so a caller can refuse
@@ -199,6 +202,10 @@ def _aggressive_fallback(pred: Prediction) -> Prediction:
     The aggressive policy is "if no DB or diagnoser confidently asserted real,
     treat as fabricated"; we type the residual as ``plausible_fabrication``
     since that is the catch-all for "looks plausible but unverifiable".
+
+    The function itself is unchanged and unconditional; whether it runs at all is
+    decided in ``run_cascade_with_health``, which skips the promotion entirely on
+    a batch flagged by ``BatchHealth.suspected_transport_failure``.
     """
     if pred.label == "HALLUCINATED":
         return pred
@@ -262,7 +269,9 @@ def run_cascade_with_health(
         aggressive: if True, any entry still UNCERTAIN/low-confidence VALID
             after Stage 2 is forced to HALLUCINATED@0.55 with type
             ``plausible_fabrication``. This implements the "DB-as-gold-standard"
-            stance from the reviewer feedback.
+            stance from the reviewer feedback. The promotion is skipped when
+            ``health.suspected_transport_failure`` is set, since a batch with no
+            database evidence has no gold standard to stand on.
         stage2_kwargs: kwargs forwarded to the Stage 2 baseline runner.
         **stage1_kwargs: forwarded to ``run_bibtex_check_with_status``.
 
@@ -271,6 +280,19 @@ def run_cascade_with_health(
         map: when ``health.suspected_transport_failure`` is True the Stage 1
         lookups produced no database evidence, every Stage 2 verdict in the batch
         rests on nothing, and the caller must not checkpoint the results.
+
+    Note on the published results
+    -----------------------------
+    The aggressive-mode numbers in the paper were produced before this guard
+    existed, and they are not recomputed by it: they are frozen files in
+    ``data/v1.2/baseline_results/`` that CI validates by checksum rather than
+    re-running.  The guard cannot alter them.  It is also inert on a healthy
+    batch by construction — ``suspected_transport_failure`` is False whenever the
+    no-evidence share stays under the threshold, and the frozen conservative runs
+    bound that share below it (``cascade_breakdown_stats``: 23.8% of dev_public
+    and 26.7% of test_public deferred to Stage 2 at all, and the no-evidence
+    statuses are a subset of the deferred).  Only a future run on degraded input
+    behaves differently.
     """
     if not entries:
         return [], assess_batch_health([])
@@ -353,9 +375,25 @@ def run_cascade_with_health(
             )
 
     if aggressive:
-        for key, pred in list(final.items()):
-            if pred.cascade_stage in {"stage2_diagnosis"}:
-                final[key] = _aggressive_fallback(pred)
+        if health.suspected_transport_failure:
+            # "DB-as-gold-standard" needs a DB. With no database evidence behind
+            # the batch, promoting the residue to HALLUCINATED would turn an
+            # outage into mass fabrication verdicts, so the entries stay as
+            # Stage 2 returned them. Inert on a healthy batch: the flag is False
+            # for every run that is not degraded, so aggressive mode there is
+            # byte-identical to what it was before this guard existed.
+            logger.warning(
+                "cascade: aggressive promotion suppressed — Stage 1 produced no "
+                "database evidence for %d/%d entries, so there is no gold standard "
+                "to treat as one. Stage 2 verdicts are returned unpromoted; do not "
+                "checkpoint this batch.",
+                health.no_evidence,
+                health.total,
+            )
+        else:
+            for key, pred in list(final.items()):
+                if pred.cascade_stage in {"stage2_diagnosis"}:
+                    final[key] = _aggressive_fallback(pred)
 
     return [final[entry.bibtex_key] for entry in entries], health
 

--- a/hallmark/baselines/checkpoint_guard.py
+++ b/hallmark/baselines/checkpoint_guard.py
@@ -1,0 +1,323 @@
+"""Refuse to checkpoint a run that produced no usable verdicts.
+
+The long-running evaluation scripts (``scripts/parallel_resume_test_public.py``,
+``scripts/parallel_agentic_btu_test_public.py``) append one JSONL record per
+entry and resume by skipping the keys already in that file.  That makes a failed
+call permanent: on 2026-09-02 a wifi outage turned 2,500 consecutive lookups into
+no-evidence verdicts, and anything checkpointed during an outage is trusted by
+every later run.
+
+This module applies the same batch-level sanity check the bibtex-check wrapper
+uses (``hallmark.baselines.bibtexupdater.BatchHealth``) to the records a runner
+is about to persist:
+
+- an error record never reaches the checkpoint at all — it goes to a
+  ``.rejected-<timestamp>.jsonl`` sidecar, so the next run re-runs that key;
+- once error records cross the batch threshold the run is refused outright with
+  ``PoisonedBatchError``, before it burns more API budget.
+
+The checkpoint is therefore left holding only usable verdicts, and a refused
+batch is retried cleanly rather than resumed from.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from hallmark.baselines.bibtexupdater import (
+    MIN_BATCH_FOR_HEALTH_CHECK,
+    NOT_FOUND_SHARE_THRESHOLD,
+    BatchHealth,
+)
+
+logger = logging.getLogger(__name__)
+
+# Reason prefixes the runners and the agentic verifier use for a record that
+# carries no verdict.  ``[Salvaged]`` is deliberately absent: a salvaged record
+# has a real label parsed out of truncated output.
+ERROR_REASON_PREFIXES: tuple[str, ...] = (
+    "[Error fallback]",
+    "[Agentic error]",
+)
+
+# Substrings that identify an error record as a failed request rather than an
+# answer that could not be parsed.  Matched case-insensitively against the
+# reason, which embeds the exception class or message.
+TRANSPORT_ERROR_HINTS: tuple[str, ...] = (
+    "apierror",
+    "api error",
+    "apiconnection",
+    "apitimeout",
+    "connection",
+    "timeout",
+    "timed out",
+    "rate limit",
+    "ratelimit",
+    "429",
+    "network",
+    "dns",
+    "ssl",
+    "reset by peer",
+    "unreachable",
+    "temporarily",
+)
+
+
+class PoisonedBatchError(RuntimeError):
+    """Raised when a run's error share crosses the batch-health threshold."""
+
+    def __init__(self, health: BatchHealth, message: str) -> None:
+        super().__init__(message)
+        self.health = health
+
+
+def _reason(record: Mapping[str, Any]) -> str:
+    return str(record.get("reason") or "")
+
+
+def is_error_record(record: Mapping[str, Any]) -> bool:
+    """True when the record carries no verdict, only a failure."""
+    return _reason(record).startswith(ERROR_REASON_PREFIXES)
+
+
+def is_transport_error_record(record: Mapping[str, Any]) -> bool:
+    """True when the record's failure was a failed request, not a bad answer."""
+    if not is_error_record(record):
+        return False
+    reason = _reason(record).lower()
+    return any(hint in reason for hint in TRANSPORT_ERROR_HINTS)
+
+
+def assess_run_health(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    threshold: float = NOT_FOUND_SHARE_THRESHOLD,
+    min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK,
+) -> BatchHealth:
+    """Score a runner's records with the bibtex-check batch-health thresholds.
+
+    Error records map onto the ``BatchHealth`` counters the wrapper already uses:
+    a failed request counts as ``transport_error``, and an error record that
+    completed but yielded nothing usable counts as ``coverage_incomplete``.
+    ``not_found`` stays zero — these runners never make that claim.
+    """
+    recs = list(records)
+    transport = sum(1 for r in recs if is_transport_error_record(r))
+    unusable = sum(1 for r in recs if is_error_record(r)) - transport
+    return BatchHealth(
+        total=len(recs),
+        not_found=0,
+        transport_error=transport,
+        coverage_incomplete=unusable,
+        threshold=threshold,
+        min_batch_size=min_batch_size,
+    )
+
+
+def refusal_message(health: BatchHealth, checkpoint_path: Path) -> str:
+    """Operator-facing description of why the run was refused."""
+    return (
+        f"Refusing to checkpoint this run: {health.no_evidence}/{health.total} "
+        f"entries came back with no verdict "
+        f"({health.no_evidence_share:.1%}: {health.transport_error} failed "
+        f"requests, {health.coverage_incomplete} unusable answers), above the "
+        f"{health.threshold:.0%} threshold. A share this high is almost always a "
+        f"broken transport path — a DNS, network or proxy outage, or sustained "
+        f"throttling — rather than a property of the bibliography. Nothing was "
+        f"written to {checkpoint_path}; fix connectivity and re-run, and the "
+        f"refused entries will be retried."
+    )
+
+
+def rejected_path_for(checkpoint_path: Path, timestamp: float | None = None) -> Path:
+    """Sidecar path that holds the records this run refused to checkpoint."""
+    stamp = time.strftime("%Y%m%dT%H%M%S", time.localtime(timestamp or time.time()))
+    return checkpoint_path.with_name(f"{checkpoint_path.name}.rejected-{stamp}.jsonl")
+
+
+class RunHealthTracker:
+    """Thread-safe running tally of a run's error share.
+
+    ``add`` raises ``PoisonedBatchError`` as soon as the run crosses the batch
+    threshold, so a caller can cancel the remaining work instead of paying for
+    calls that cannot produce evidence.  Below ``min_batch_size`` records the
+    share is treated as noise and never trips (see ``BatchHealth``).
+    """
+
+    def __init__(
+        self,
+        *,
+        checkpoint_path: Path,
+        threshold: float = NOT_FOUND_SHARE_THRESHOLD,
+        min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK,
+    ) -> None:
+        self.checkpoint_path = checkpoint_path
+        self._threshold = threshold
+        self._min_batch_size = min_batch_size
+        self._lock = threading.Lock()
+        self._total = 0
+        self._transport = 0
+        self._unusable = 0
+
+    @property
+    def health(self) -> BatchHealth:
+        with self._lock:
+            return self._health_unlocked()
+
+    def _health_unlocked(self) -> BatchHealth:
+        return BatchHealth(
+            total=self._total,
+            not_found=0,
+            transport_error=self._transport,
+            coverage_incomplete=self._unusable,
+            threshold=self._threshold,
+            min_batch_size=self._min_batch_size,
+        )
+
+    def add(self, record: Mapping[str, Any]) -> BatchHealth:
+        """Fold one record into the tally; raise once the run is poisoned."""
+        with self._lock:
+            self._total += 1
+            if is_transport_error_record(record):
+                self._transport += 1
+            elif is_error_record(record):
+                self._unusable += 1
+            health = self._health_unlocked()
+        if health.suspected_transport_failure:
+            raise PoisonedBatchError(health, refusal_message(health, self.checkpoint_path))
+        return health
+
+
+class GuardedCheckpointWriter:
+    """Append usable records to the checkpoint and park failures in a sidecar.
+
+    Usable verdicts are written and flushed as they arrive, so a long run stays
+    resumable.  Error records never enter the checkpoint, which is what makes a
+    refused entry retryable: the next run does not see its key and re-runs it.
+    """
+
+    def __init__(
+        self,
+        checkpoint_path: Path,
+        *,
+        threshold: float = NOT_FOUND_SHARE_THRESHOLD,
+        min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK,
+    ) -> None:
+        self.checkpoint_path = checkpoint_path
+        self.rejected_path = rejected_path_for(checkpoint_path)
+        self.tracker = RunHealthTracker(
+            checkpoint_path=checkpoint_path,
+            threshold=threshold,
+            min_batch_size=min_batch_size,
+        )
+        self.written = 0
+        self.rejected = 0
+        self._lock = threading.Lock()
+        self._checkpoint_file: Any = None
+        self._rejected_file: Any = None
+
+    def __enter__(self) -> GuardedCheckpointWriter:
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        self._checkpoint_file = self.checkpoint_path.open("a")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def add(self, record: Mapping[str, Any]) -> None:
+        """Persist one record, or park it; raise when the run turns poisoned."""
+        error = is_error_record(record)
+        with self._lock:
+            if error:
+                self._write_rejected(record)
+                self.rejected += 1
+            else:
+                self._write_checkpoint(record)
+                self.written += 1
+        # Outside the write lock: the tracker has its own.
+        self.tracker.add(record)
+
+    def _write_checkpoint(self, record: Mapping[str, Any]) -> None:
+        if self._checkpoint_file is None:
+            self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+            self._checkpoint_file = self.checkpoint_path.open("a")
+        self._checkpoint_file.write(json.dumps(dict(record)) + "\n")
+        self._checkpoint_file.flush()
+        os.fsync(self._checkpoint_file.fileno())
+
+    def _write_rejected(self, record: Mapping[str, Any]) -> None:
+        if self._rejected_file is None:
+            self.rejected_path.parent.mkdir(parents=True, exist_ok=True)
+            self._rejected_file = self.rejected_path.open("a")
+        self._rejected_file.write(json.dumps(dict(record)) + "\n")
+        self._rejected_file.flush()
+
+    def close(self) -> None:
+        for handle in (self._checkpoint_file, self._rejected_file):
+            if handle is not None:
+                handle.close()
+        self._checkpoint_file = None
+        self._rejected_file = None
+        if self.rejected:
+            logger.warning(
+                "%d record(s) carried no verdict and were parked in %s — their "
+                "keys are absent from %s, so the next run retries them.",
+                self.rejected,
+                self.rejected_path,
+                self.checkpoint_path,
+            )
+
+
+def quarantine_error_records(checkpoint_path: Path, keys: set[str]) -> Path | None:
+    """Move error lines for ``keys`` out of a checkpoint into a sidecar.
+
+    For runners whose checkpoint is written by the verifier itself, so the guard
+    cannot intercept the write.  The checkpoint is rewritten atomically via a
+    temporary file and ``os.replace``; every line that is not an error record for
+    one of ``keys`` survives unchanged and in order.
+
+    Returns the sidecar path, or None when there was nothing to quarantine.
+    """
+    if not keys or not checkpoint_path.exists():
+        return None
+
+    kept: list[str] = []
+    moved: list[str] = []
+    for line in checkpoint_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            kept.append(line)
+            continue
+        if record.get("bibtex_key") in keys and is_error_record(record):
+            moved.append(line)
+        else:
+            kept.append(line)
+
+    if not moved:
+        return None
+
+    sidecar = rejected_path_for(checkpoint_path)
+    with sidecar.open("a") as f:
+        f.write("\n".join(moved) + "\n")
+
+    tmp = checkpoint_path.with_name(checkpoint_path.name + ".tmp")
+    tmp.write_text("".join(line + "\n" for line in kept))
+    os.replace(tmp, checkpoint_path)
+    logger.warning(
+        "Quarantined %d error record(s) from %s into %s — those keys will be "
+        "retried on the next run.",
+        len(moved),
+        checkpoint_path,
+        sidecar,
+    )
+    return sidecar

--- a/scripts/parallel_agentic_btu_test_public.py
+++ b/scripts/parallel_agentic_btu_test_public.py
@@ -19,6 +19,16 @@ Resume semantics: skips bibtex_keys present in the existing checkpoint
 JSONL (matching pattern `agentic_btu_openai_<safe_model>.jsonl` written by
 the underlying verifier). Smoke-test with `--max-entries 3 --workers 2`.
 
+Records whose reason marks a failure (`[Agentic error]` / `[Error fallback]`)
+are NOT treated as done — they are retried, matching what
+``llm_agentic._load_checkpoint(skip_failed=True)`` already does. The verifier
+writes its own checkpoint line, so a poisoned line cannot be intercepted before
+the write; instead, once the failed share of the run crosses the batch-health
+threshold the run is refused, the failed lines this run added are quarantined
+into a `<jsonl>.rejected-<timestamp>.jsonl` sidecar, and the process exits
+non-zero. A share that high is a transport outage, not a property of the
+bibliography, and checkpointing it is what makes an outage permanent.
+
 Rate-limit notes
 ================
 OpenRouter:        ~200 RPM cap on chat completions for paid users.
@@ -36,7 +46,6 @@ import json
 import logging
 import os
 import sys
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -49,6 +58,12 @@ sys.path.insert(0, str(ROOT))
 # not by mutating ``os.environ``. The CLI ``hallmark evaluate --workers N``
 # is the recommended entry point; this script remains as a thin shim.
 
+from hallmark.baselines.checkpoint_guard import (  # noqa: E402
+    PoisonedBatchError,
+    RunHealthTracker,
+    is_error_record,
+    quarantine_error_records,
+)
 from hallmark.baselines.llm_agentic import (  # noqa: E402
     verify_agentic_btu_openai,
     verify_agentic_openai,
@@ -81,6 +96,15 @@ def _checkpoint_path(checkpoint_dir: Path, model: str) -> Path:
 
 
 def _read_done_keys(jsonl_path: Path) -> set[str]:
+    """Keys with a real verdict in the checkpoint.
+
+    A record whose reason marks a failure is not done: it carries no verdict, and
+    counting it as done is what froze a wifi outage into 2,500 permanent
+    ``not_found``-shaped results on 2026-09-02. Failed keys are dropped here so
+    the next run retries them, the same rule
+    ``llm_agentic._load_checkpoint(skip_failed=True)`` applies. A later good
+    record for the same key wins over an earlier failed one.
+    """
     if not jsonl_path.exists():
         return set()
     keys: set[str] = set()
@@ -88,7 +112,11 @@ def _read_done_keys(jsonl_path: Path) -> set[str]:
         if not line.strip():
             continue
         rec = json.loads(line)
-        keys.add(rec["bibtex_key"])
+        key = rec["bibtex_key"]
+        if is_error_record(rec):
+            keys.discard(key)
+        else:
+            keys.add(key)
     return keys
 
 
@@ -148,9 +176,11 @@ def main() -> None:
         logger.info("Nothing to do.")
         return
 
-    lock = threading.Lock()
     completed = 0
     start = time.time()
+    tracker = RunHealthTracker(checkpoint_path=jsonl_path)
+    poisoned: PoisonedBatchError | None = None
+    run_keys: set[str] = set()
 
     or_api_key = os.environ.get("OPENROUTER_API_KEY")
     if not or_api_key:
@@ -195,17 +225,31 @@ def main() -> None:
         }
 
     # The underlying verify_agentic_btu_openai writes its own per-entry
-    # checkpoint line; we just track completion here for progress logging.
+    # checkpoint line, so the guard cannot intercept the write; it scores the
+    # records the run produced and quarantines the failed lines afterwards.
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
         futures = {ex.submit(call_one, e): e for e in remaining}
         for fut in as_completed(futures):
             entry = futures[fut]
             try:
-                _ = fut.result()
+                rec = fut.result()
             except Exception as e:
                 logger.exception("Unhandled error on %s: %s", entry.bibtex_key, e)
-            with lock:
-                pass
+                rec = {
+                    "bibtex_key": getattr(entry, "bibtex_key", "?"),
+                    "label": "UNCERTAIN",
+                    "confidence": 0.5,
+                    "reason": f"[Error fallback] Unhandled: {e}",
+                }
+            run_keys.add(str(rec.get("bibtex_key", "")))
+            try:
+                tracker.add(rec)
+            except PoisonedBatchError as exc:
+                poisoned = exc
+                logger.error("%s", exc)
+                for pending in futures:
+                    pending.cancel()
+                break
             completed += 1
             if completed % 5 == 0:
                 elapsed = time.time() - start
@@ -218,6 +262,11 @@ def main() -> None:
                     rate,
                     eta_min,
                 )
+
+    if poisoned is not None:
+        sidecar = quarantine_error_records(jsonl_path, run_keys)
+        detail = f"\nRefused records: {sidecar}" if sidecar else ""
+        raise SystemExit(f"{poisoned}{detail}")
 
     logger.info("Done. Processed %d entries.", completed)
 

--- a/scripts/parallel_resume_test_public.py
+++ b/scripts/parallel_resume_test_public.py
@@ -38,6 +38,16 @@ Usage:
 
 After completion, run `hallmark evaluate --predictions <jsonl>` to compute
 the eval.json from the assembled predictions.
+
+Checkpoint guard
+================
+Records are written through ``GuardedCheckpointWriter``: a record that carries no
+verdict (an ``[Error fallback]`` reason) never enters the checkpoint, so its key
+is absent on the next run and gets retried instead of being trusted forever.  It
+is parked in a ``<jsonl>.rejected-<timestamp>.jsonl`` sidecar.  Once the failed
+share of the run crosses the batch-health threshold the run is refused outright
+and exits non-zero, on the reasoning that a share that high is a transport outage
+rather than a property of the bibliography.
 """
 
 from __future__ import annotations
@@ -48,7 +58,6 @@ import logging
 import os
 import re
 import sys
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -58,6 +67,10 @@ import openai
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from hallmark.baselines.checkpoint_guard import (  # noqa: E402
+    GuardedCheckpointWriter,
+    PoisonedBatchError,
+)
 from hallmark.baselines.llm_verifier import VERIFICATION_PROMPT  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -405,11 +418,14 @@ def main() -> None:
         logger.info("Nothing to do.")
         return
 
-    lock = threading.Lock()
     completed = 0
     run_start = time.time()
+    poisoned: PoisonedBatchError | None = None
 
-    with jsonl_path.open("a") as f, ThreadPoolExecutor(max_workers=args.workers) as ex:
+    with (
+        GuardedCheckpointWriter(jsonl_path) as writer,
+        ThreadPoolExecutor(max_workers=args.workers) as ex,
+    ):
         futures = {
             ex.submit(
                 call_one,
@@ -440,9 +456,17 @@ def main() -> None:
                     "api_sources_queried": [],
                 }
 
-            with lock:
-                f.write(json.dumps(rec) + "\n")
-                f.flush()
+            try:
+                writer.add(rec)
+            except PoisonedBatchError as exc:
+                # Stop paying for calls that cannot produce evidence. Only usable
+                # verdicts reached the checkpoint, so every refused key is
+                # retried by the next run.
+                poisoned = exc
+                logger.error("%s", exc)
+                for pending in futures:
+                    pending.cancel()
+                break
 
             completed += 1
             if completed % 10 == 0:
@@ -457,7 +481,10 @@ def main() -> None:
                     eta_min,
                 )
 
-    logger.info("Done. Wrote %d new predictions to %s", completed, jsonl_path)
+    if poisoned is not None:
+        raise SystemExit(f"{poisoned}\nRefused records: {writer.rejected_path}")
+
+    logger.info("Done. Wrote %d new predictions to %s", writer.written, jsonl_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -7,6 +7,12 @@ pre-1.2.0 records, 1.2.0 realness records (``confidence_score`` /
 following the pattern of ``TestParseJsonlToRaw`` in
 ``test_llm_tool_augmented.py``.
 
+Also covers the batch-level sanity check (``assess_batch_health``), added after a
+2026-09-02 wifi outage made bibtex-check return ``not_found`` for 2,500
+consecutive references: every source lookup failed DNS resolution, and nothing in
+HALLMARK noticed that a whole batch had arrived with no database evidence behind
+it.
+
 These tests live in their own module (not ``test_baselines.py``) because that
 module is skipped entirely when the optional ``openai`` dependency is absent.
 """
@@ -14,17 +20,23 @@ module is skipped entirely when the optional ``openai`` dependency is absent.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from hallmark.baselines.bibtexupdater import (
+    MIN_BATCH_FOR_HEALTH_CHECK,
+    NOT_FOUND_SHARE_THRESHOLD,
     STATUS_TO_CONFIDENCE,
     STATUS_TO_LABEL,
     _parse_jsonl_output,
+    assess_batch_health,
+    run_bibtex_check_with_health,
+    run_bibtex_check_with_status,
 )
-from hallmark.dataset.schema import Prediction
+from hallmark.dataset.schema import BlindEntry, Prediction
 
 
 def _parse(tmp_path: Path, records: list[dict[str, Any]]) -> list[Prediction]:
@@ -197,3 +209,202 @@ class TestParseJsonlOutput:
         assert pred.label == "VALID"
         assert pred.confidence == pytest.approx(0.5)
         assert "abstention" not in pred.reason
+
+
+class TestTransportStatusMapping:
+    """A failed lookup is an abstention, never evidence of fabrication."""
+
+    def test_network_error_is_a_conservative_valid(self) -> None:
+        assert STATUS_TO_LABEL["network_error"] == "VALID"
+        assert STATUS_TO_CONFIDENCE["network_error"] == 0.30
+
+    def test_coverage_incomplete_status_is_a_conservative_valid(self) -> None:
+        assert STATUS_TO_LABEL["coverage_incomplete"] == "VALID"
+        assert STATUS_TO_CONFIDENCE["coverage_incomplete"] == 0.45
+
+    def test_network_error_record_never_parses_to_hallucinated(self, tmp_path: Path) -> None:
+        """The status the upgraded tool emits for a DNS/connection failure."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "n",
+                "status": "network_error",
+                "confidence": 0.0,
+                "mismatched_fields": [],
+                "api_sources": [],
+                "errors": ["crossref: [Errno 8] nodename nor servname provided"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+        assert pred.label != "HALLUCINATED"
+
+    def test_unknown_future_status_never_parses_to_hallucinated(self, tmp_path: Path) -> None:
+        """Whatever the sibling tool names its new transport status, an unmapped
+        status falls through to conservative VALID rather than a fabrication
+        verdict."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "u",
+                "status": "transport_failure_some_future_name",
+                "confidence": 0.0,
+                "mismatched_fields": [],
+                "api_sources": [],
+                "errors": ["dns failure"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+
+
+class TestAssessBatchHealth:
+    """The 2026-09-02 incident: 85-98% ``not_found`` with no database behind it."""
+
+    def test_poisoned_batch_trips_the_detector(self) -> None:
+        statuses = ["not_found"] * 95 + ["verified"] * 5
+        health = assess_batch_health(statuses)
+        assert health.suspected_transport_failure
+        assert health.not_found == 95
+        assert health.no_evidence_share == pytest.approx(0.95)
+
+    def test_healthy_batch_does_not_trip_the_detector(self) -> None:
+        """Healthy runs: ~52% verified, 1-3% not_found."""
+        statuses = ["verified"] * 52 + ["not_found"] * 3 + ["unconfirmed"] * 45
+        health = assess_batch_health(statuses)
+        assert not health.suspected_transport_failure
+        assert health.not_found_share == pytest.approx(0.03)
+
+    def test_all_network_error_batch_trips_the_detector(self) -> None:
+        """Same outage seen through the upgraded tool's own status."""
+        health = assess_batch_health(["network_error"] * 100)
+        assert health.suspected_transport_failure
+        assert health.transport_error == 100
+        assert health.not_found == 0
+
+    def test_coverage_incomplete_status_counts_as_no_evidence(self) -> None:
+        health = assess_batch_health(["coverage_incomplete"] * 100)
+        assert health.suspected_transport_failure
+        assert health.coverage_incomplete == 100
+
+    def test_mixed_failure_shapes_accumulate(self) -> None:
+        """A partially-upgraded pipeline splits the same outage across statuses;
+        neither share alone crosses the threshold, together they do."""
+        statuses = ["not_found"] * 20 + ["network_error"] * 20 + ["verified"] * 60
+        health = assess_batch_health(statuses)
+        assert health.not_found_share == pytest.approx(0.20)
+        assert health.transport_error_share == pytest.approx(0.20)
+        assert health.suspected_transport_failure
+
+    def test_small_batch_is_not_judged(self) -> None:
+        """Below the minimum batch size the share is noise, not signal."""
+        statuses = ["not_found"] * (MIN_BATCH_FOR_HEALTH_CHECK - 1)
+        health = assess_batch_health(statuses)
+        assert not health.suspected_transport_failure
+        assert health.no_evidence_share == pytest.approx(1.0)
+
+    def test_empty_batch_is_safe(self) -> None:
+        health = assess_batch_health([])
+        assert not health.suspected_transport_failure
+        assert health.no_evidence_share == 0.0
+
+    def test_threshold_boundary_is_exclusive(self) -> None:
+        statuses = ["not_found"] * 30 + ["verified"] * 70
+        health = assess_batch_health(statuses)
+        assert health.no_evidence_share == pytest.approx(NOT_FOUND_SHARE_THRESHOLD)
+        assert not health.suspected_transport_failure
+
+    def test_missing_sentinel_is_not_counted(self) -> None:
+        """A timeout is already reported by the subprocess runner; it is a
+        different failure and must not be read as a transport outage."""
+        health = assess_batch_health(["missing"] * 100)
+        assert not health.suspected_transport_failure
+
+    def test_warning_message_blames_the_lookup_path_not_the_bibliography(
+        self,
+    ) -> None:
+        health = assess_batch_health(["not_found"] * 98 + ["verified"] * 2)
+        message = health.warning_message()
+        assert "98/100" in message
+        assert "98.0%" in message
+        assert "do not" in message.lower()
+        assert "checkpoint" in message
+        assert "invented papers" in message
+
+
+def _blind(key: str) -> BlindEntry:
+    return BlindEntry(
+        bibtex_key=key,
+        bibtex_type="article",
+        fields={"title": "T", "author": "A", "year": "2024"},
+        raw_bibtex=f"@article{{{key}, title={{T}}}}",
+    )
+
+
+def _fake_subprocess(status: str) -> Any:
+    def _run(entries: list[BlindEntry], **_kw: Any) -> list[Prediction]:
+        return [
+            Prediction(
+                bibtex_key=e.bibtex_key,
+                label=STATUS_TO_LABEL.get(status, "VALID"),  # type: ignore[arg-type]
+                confidence=STATUS_TO_CONFIDENCE.get(status, 0.5),
+                reason=f"Status: {status}",
+            )
+            for e in entries
+        ]
+
+    return _run
+
+
+class TestBatchHealthPlumbing:
+    """The signal reaches the caller, not only the log."""
+
+    def test_poisoned_run_logs_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            "hallmark.baselines.bibtexupdater._run_bibtex_check_subprocess",
+            _fake_subprocess("not_found"),
+        )
+        entries = [_blind(f"k{i}") for i in range(40)]
+        with caplog.at_level(logging.WARNING, logger="hallmark.baselines.bibtexupdater"):
+            _, status_map = run_bibtex_check_with_status(entries, skip_prescreening=True)
+        assert set(status_map.values()) == {"not_found"}
+        assert any("do not" in r.message.lower() for r in caplog.records)
+        assert any("40/40" in r.message for r in caplog.records)
+
+    def test_healthy_run_logs_no_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            "hallmark.baselines.bibtexupdater._run_bibtex_check_subprocess",
+            _fake_subprocess("verified"),
+        )
+        entries = [_blind(f"k{i}") for i in range(40)]
+        with caplog.at_level(logging.WARNING, logger="hallmark.baselines.bibtexupdater"):
+            run_bibtex_check_with_status(entries, skip_prescreening=True)
+        assert not [r for r in caplog.records if "checkpoint" in r.message]
+
+    def test_with_health_returns_the_flag_a_caller_gates_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "hallmark.baselines.bibtexupdater._run_bibtex_check_subprocess",
+            _fake_subprocess("network_error"),
+        )
+        entries = [_blind(f"k{i}") for i in range(40)]
+        predictions, status_map, health = run_bibtex_check_with_health(
+            entries, skip_prescreening=True
+        )
+        assert len(predictions) == 40
+        assert set(status_map.values()) == {"network_error"}
+        assert health.suspected_transport_failure
+        assert health.transport_error == 40
+        assert all(p.label != "HALLUCINATED" for p in predictions)
+
+    def test_with_health_is_quiet_on_a_healthy_batch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "hallmark.baselines.bibtexupdater._run_bibtex_check_subprocess",
+            _fake_subprocess("verified"),
+        )
+        entries = [_blind(f"k{i}") for i in range(40)]
+        _, _, health = run_bibtex_check_with_health(entries, skip_prescreening=True)
+        assert not health.suspected_transport_failure

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -14,6 +14,7 @@ from hallmark.baselines.cascade import (
     _aggressive_fallback,
     _stage1_predict,
     run_cascade,
+    run_cascade_with_health,
 )
 from hallmark.dataset.schema import BlindEntry, Prediction
 
@@ -395,3 +396,95 @@ def test_prediction_rejects_invalid_predicted_type() -> None:
             confidence=0.9,
             predicted_hallucination_type="not_a_real_type",
         )
+
+
+# ---------------------------------------------------------------------------
+# Failed-lookup routing and the batch-level sanity check
+#
+# 2026-09-02: a wifi outage made every source lookup fail DNS resolution,
+# bibtex-check returned ``not_found`` for 2,500 consecutive references, and the
+# cascade forwarded all of them to an expensive Stage 2 with no database
+# evidence behind any of them.
+# ---------------------------------------------------------------------------
+
+
+def test_transport_statuses_route_to_stage2_and_carry_no_type() -> None:
+    """A failed request is not a fabricated reference."""
+    for status in ("network_error", "coverage_incomplete"):
+        assert status in ROUTE_TO_STAGE2
+        assert status not in STATUS_TO_TYPE
+        assert status not in STAGE1_VERIFIED
+
+
+def test_stage1_network_error_defers_instead_of_deciding() -> None:
+    out = _stage1_predict(_entry("k"), _raw("k", label="VALID"), "network_error")
+    assert out is None
+
+
+def test_stage1_never_emits_hallucinated_for_a_failed_lookup() -> None:
+    """Whatever the upgraded tool names its transport status, Stage 1 must not
+    turn it into a fabrication verdict."""
+    for status in (
+        "network_error",
+        "coverage_incomplete",
+        "api_error",
+        "transport_failure_some_future_name",
+    ):
+        out = _stage1_predict(_entry("k"), _raw("k", label="VALID"), status)
+        assert out is None or out.label != "HALLUCINATED", status
+
+
+def test_unmapped_status_defers_to_stage2_deliberately() -> None:
+    """Open-world default: an unknown status is routed on, never decided here."""
+    assert _stage1_predict(_entry("k"), _raw("k"), "a_status_from_the_future") is None
+
+
+def test_cascade_network_error_reaches_stage2_and_stays_valid() -> None:
+    entries = [_entry("a")]
+    name = _mock_stage2({"a": {"label": "VALID", "confidence": 0.9}})
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1({"a": "network_error"}),
+    ):
+        preds = run_cascade(entries, stage2_baseline=name)
+
+    assert preds[0].label == "VALID"
+    assert preds[0].label != "HALLUCINATED"
+    assert preds[0].cascade_stage == "stage2_diagnosis"
+
+
+def test_cascade_exposes_poisoned_batch_health() -> None:
+    """The signal a checkpointing caller gates on."""
+    entries = [_entry(f"k{i}") for i in range(40)]
+    statuses = {e.bibtex_key: "not_found" for e in entries}
+    name = _mock_stage2({e.bibtex_key: {"label": "UNCERTAIN"} for e in entries})
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(statuses),
+    ):
+        preds, health = run_cascade_with_health(entries, stage2_baseline=name)
+
+    assert len(preds) == 40
+    assert health.suspected_transport_failure
+    assert health.not_found == 40
+
+
+def test_cascade_health_is_clean_on_a_normal_batch() -> None:
+    entries = [_entry(f"k{i}") for i in range(40)]
+    statuses = {e.bibtex_key: "verified" for e in entries}
+    statuses["k0"] = "not_found"
+    name = _mock_stage2({"k0": {"label": "UNCERTAIN"}})
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(statuses),
+    ):
+        preds, health = run_cascade_with_health(entries, stage2_baseline=name)
+
+    assert len(preds) == 40
+    assert not health.suspected_transport_failure
+
+
+def test_cascade_with_health_handles_empty_input() -> None:
+    preds, health = run_cascade_with_health([])
+    assert preds == []
+    assert not health.suspected_transport_failure

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -488,3 +488,104 @@ def test_cascade_with_health_handles_empty_input() -> None:
     preds, health = run_cascade_with_health([])
     assert preds == []
     assert not health.suspected_transport_failure
+
+
+# ---------------------------------------------------------------------------
+# Aggressive promotion is gated on batch health
+#
+# "DB-as-gold-standard" needs a DB. During an outage there is no database
+# evidence to be a gold standard, so promoting the Stage 2 residue would turn a
+# failed network into mass fabrication verdicts.
+# ---------------------------------------------------------------------------
+
+
+def _uncertain_stage2(keys: list[str]) -> str:
+    return _mock_stage2({k: {"label": "UNCERTAIN", "confidence": 0.5} for k in keys})
+
+
+def test_aggressive_promotion_suppressed_on_a_poisoned_batch() -> None:
+    entries = [_entry(f"k{i}") for i in range(40)]
+    keys = [e.bibtex_key for e in entries]
+    name = _uncertain_stage2(keys)
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(dict.fromkeys(keys, "not_found")),
+    ):
+        preds, health = run_cascade_with_health(entries, stage2_baseline=name, aggressive=True)
+
+    assert health.suspected_transport_failure
+    assert all(p.label == "UNCERTAIN" for p in preds)
+    assert not any(p.label == "HALLUCINATED" for p in preds)
+    assert all(p.predicted_hallucination_type is None for p in preds)
+
+
+def test_aggressive_promotion_suppressed_for_network_error_statuses() -> None:
+    """Same suppression through the upgraded tool's own transport status."""
+    entries = [_entry(f"k{i}") for i in range(40)]
+    keys = [e.bibtex_key for e in entries]
+    name = _uncertain_stage2(keys)
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(dict.fromkeys(keys, "network_error")),
+    ):
+        preds, health = run_cascade_with_health(entries, stage2_baseline=name, aggressive=True)
+
+    assert health.suspected_transport_failure
+    assert all(p.label == "UNCERTAIN" for p in preds)
+
+
+def test_aggressive_promotion_still_fires_on_a_healthy_batch() -> None:
+    """The published aggressive-mode behaviour, pinned."""
+    entries = [_entry(f"k{i}") for i in range(40)]
+    keys = [e.bibtex_key for e in entries]
+    statuses = dict.fromkeys(keys, "verified")
+    statuses["k0"] = "not_found"
+    name = _mock_stage2({"k0": {"label": "UNCERTAIN", "confidence": 0.5}})
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(statuses),
+    ):
+        preds, health = run_cascade_with_health(entries, stage2_baseline=name, aggressive=True)
+
+    assert not health.suspected_transport_failure
+    promoted = next(p for p in preds if p.bibtex_key == "k0")
+    assert promoted.label == "HALLUCINATED"
+    assert promoted.confidence == pytest.approx(0.55)
+    assert promoted.predicted_hallucination_type == "plausible_fabrication"
+    assert promoted.reason.startswith("[Aggressive: unverifiable]")
+
+
+def test_healthy_aggressive_output_is_unchanged_by_the_guard() -> None:
+    """Bit-for-bit pin: on a healthy batch, gating aggressive mode on health is
+    the same as applying ``_aggressive_fallback`` unconditionally, which is what
+    produced the frozen numbers in ``data/v1.2/baseline_results/``."""
+    from dataclasses import asdict
+
+    entries = [_entry(f"k{i}") for i in range(40)]
+    keys = [e.bibtex_key for e in entries]
+    statuses = dict.fromkeys(keys, "verified")
+    for k in ("k0", "k1", "k2", "k3", "k4"):
+        statuses[k] = "not_found"
+    verdicts: dict[str, dict[str, Any]] = {
+        "k0": {"label": "UNCERTAIN", "confidence": 0.5},
+        "k1": {"label": "VALID", "confidence": 0.4},
+        "k2": {"label": "VALID", "confidence": 0.95},
+        "k3": {"label": "HALLUCINATED", "confidence": 0.8},
+        "k4": {"label": "UNCERTAIN", "confidence": 0.5},
+    }
+    name = _mock_stage2(verdicts)
+
+    with patch(
+        "hallmark.baselines.cascade.run_bibtex_check_with_status",
+        _mock_stage1(statuses),
+    ):
+        guarded = run_cascade(entries, stage2_baseline=name, aggressive=True)
+        conservative = run_cascade(entries, stage2_baseline=name, aggressive=False)
+
+    # Reconstruct the pre-guard behaviour: unconditional promotion of every
+    # Stage 2 verdict.
+    expected = [
+        _aggressive_fallback(p) if p.cascade_stage == "stage2_diagnosis" else p
+        for p in conservative
+    ]
+    assert [asdict(p) for p in guarded] == [asdict(p) for p in expected]

--- a/tests/test_checkpoint_guard.py
+++ b/tests/test_checkpoint_guard.py
@@ -1,0 +1,344 @@
+"""Tests for the checkpoint guard that refuses to persist an evidence-free run.
+
+The 2026-09-02 incident had two halves. The first was bibtex-check reporting a
+wifi outage as ``not_found``; the second, covered here, is that the long-running
+evaluation scripts checkpointed the resulting records and then skipped those keys
+on every later run, which is what made the loss permanent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hallmark.baselines.checkpoint_guard import (
+    GuardedCheckpointWriter,
+    PoisonedBatchError,
+    RunHealthTracker,
+    assess_run_health,
+    is_error_record,
+    is_transport_error_record,
+    quarantine_error_records,
+    refusal_message,
+    rejected_path_for,
+)
+
+_HAS_OPENAI = importlib.util.find_spec("openai") is not None
+
+
+def _ok(key: str) -> dict[str, Any]:
+    return {
+        "bibtex_key": key,
+        "label": "VALID",
+        "confidence": 0.9,
+        "reason": "verified against crossref",
+    }
+
+
+def _api_error(key: str) -> dict[str, Any]:
+    return {
+        "bibtex_key": key,
+        "label": "UNCERTAIN",
+        "confidence": 0.5,
+        "reason": "[Error fallback] API error: APIConnectionError: Connection error.",
+    }
+
+
+def _parse_error(key: str) -> dict[str, Any]:
+    return {
+        "bibtex_key": key,
+        "label": "UNCERTAIN",
+        "confidence": 0.5,
+        "reason": "[Error fallback] Parse error: {garbled",
+    }
+
+
+def _read(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestRecordClassification:
+    def test_verdict_record_is_not_an_error(self) -> None:
+        assert not is_error_record(_ok("a"))
+        assert not is_transport_error_record(_ok("a"))
+
+    def test_api_error_is_a_transport_failure(self) -> None:
+        assert is_error_record(_api_error("a"))
+        assert is_transport_error_record(_api_error("a"))
+
+    def test_agentic_error_prefix_is_recognised(self) -> None:
+        rec = {"bibtex_key": "a", "reason": "[Agentic error] RateLimitError: 429"}
+        assert is_error_record(rec)
+        assert is_transport_error_record(rec)
+
+    def test_parse_error_is_unusable_but_not_transport(self) -> None:
+        assert is_error_record(_parse_error("a"))
+        assert not is_transport_error_record(_parse_error("a"))
+
+    def test_salvaged_record_is_a_verdict(self) -> None:
+        """A salvaged record has a real label parsed out of truncated output."""
+        rec = {
+            "bibtex_key": "a",
+            "label": "HALLUCINATED",
+            "reason": "[Salvaged] label/confidence extracted from truncated JSON",
+        }
+        assert not is_error_record(rec)
+
+
+class TestAssessRunHealth:
+    def test_outage_run_trips(self) -> None:
+        records = [_api_error(f"k{i}") for i in range(38)] + [_ok(f"g{i}") for i in range(2)]
+        health = assess_run_health(records)
+        assert health.suspected_transport_failure
+        assert health.transport_error == 38
+        assert health.no_evidence_share == pytest.approx(0.95)
+
+    def test_normal_run_does_not_trip(self) -> None:
+        records = [_ok(f"k{i}") for i in range(38)] + [_api_error(f"e{i}") for i in range(2)]
+        health = assess_run_health(records)
+        assert not health.suspected_transport_failure
+
+    def test_unusable_answers_count_toward_the_share(self) -> None:
+        records = [_parse_error(f"k{i}") for i in range(40)]
+        health = assess_run_health(records)
+        assert health.suspected_transport_failure
+        assert health.transport_error == 0
+        assert health.coverage_incomplete == 40
+
+    def test_short_run_is_not_judged(self) -> None:
+        health = assess_run_health([_api_error(f"k{i}") for i in range(10)])
+        assert not health.suspected_transport_failure
+
+    def test_refusal_message_names_the_cause_and_the_remedy(self) -> None:
+        health = assess_run_health([_api_error(f"k{i}") for i in range(40)])
+        message = refusal_message(health, Path("/tmp/ckpt.jsonl"))
+        assert "40/40" in message
+        assert "transport" in message
+        assert "retried" in message
+        assert "/tmp/ckpt.jsonl" in message
+
+
+class TestRunHealthTracker:
+    def test_tracker_raises_once_the_run_is_poisoned(self, tmp_path: Path) -> None:
+        tracker = RunHealthTracker(checkpoint_path=tmp_path / "c.jsonl")
+        with pytest.raises(PoisonedBatchError) as excinfo:
+            for i in range(40):
+                tracker.add(_api_error(f"k{i}"))
+        assert excinfo.value.health.suspected_transport_failure
+
+    def test_tracker_stays_quiet_on_a_normal_run(self, tmp_path: Path) -> None:
+        tracker = RunHealthTracker(checkpoint_path=tmp_path / "c.jsonl")
+        for i in range(40):
+            tracker.add(_ok(f"k{i}"))
+        assert not tracker.health.suspected_transport_failure
+        assert tracker.health.total == 40
+
+
+class TestGuardedCheckpointWriter:
+    def test_verdicts_are_checkpointed(self, tmp_path: Path) -> None:
+        path = tmp_path / "ckpt.jsonl"
+        with GuardedCheckpointWriter(path) as writer:
+            for i in range(5):
+                writer.add(_ok(f"k{i}"))
+        assert [r["bibtex_key"] for r in _read(path)] == [f"k{i}" for i in range(5)]
+        assert writer.written == 5
+        assert not writer.rejected_path.exists()
+
+    def test_error_records_never_reach_the_checkpoint(self, tmp_path: Path) -> None:
+        """The core of the incident: a failed call must stay retryable."""
+        path = tmp_path / "ckpt.jsonl"
+        with GuardedCheckpointWriter(path) as writer:
+            writer.add(_ok("good"))
+            writer.add(_api_error("bad"))
+        keys = {r["bibtex_key"] for r in _read(path)}
+        assert keys == {"good"}
+        assert "bad" not in keys
+        assert [r["bibtex_key"] for r in _read(writer.rejected_path)] == ["bad"]
+
+    def test_poisoned_run_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "ckpt.jsonl"
+        writer = GuardedCheckpointWriter(path)
+        with pytest.raises(PoisonedBatchError), writer:
+            for i in range(40):
+                writer.add(_api_error(f"k{i}"))
+        # Nothing usable arrived, so the checkpoint holds nothing and every key
+        # is retried by the next run.
+        assert _read(path) == []
+        assert len(_read(writer.rejected_path)) >= 1
+
+    def test_healthy_prefix_survives_a_later_outage(self, tmp_path: Path) -> None:
+        """An outage mid-run keeps the verdicts already earned."""
+        path = tmp_path / "ckpt.jsonl"
+        writer = GuardedCheckpointWriter(path)
+        with pytest.raises(PoisonedBatchError), writer:
+            for i in range(30):
+                writer.add(_ok(f"g{i}"))
+            for i in range(30):
+                writer.add(_api_error(f"b{i}"))
+        keys = {r["bibtex_key"] for r in _read(path)}
+        assert keys == {f"g{i}" for i in range(30)}
+        assert not any(k.startswith("b") for k in keys)
+
+    def test_rejected_path_is_a_sidecar_of_the_checkpoint(self, tmp_path: Path) -> None:
+        path = tmp_path / "ckpt.jsonl"
+        sidecar = rejected_path_for(path)
+        assert sidecar.parent == path.parent
+        assert sidecar.name.startswith("ckpt.jsonl.rejected-")
+        assert sidecar.name.endswith(".jsonl")
+
+
+class TestQuarantineErrorRecords:
+    def test_only_this_run_s_error_lines_move(self, tmp_path: Path) -> None:
+        path = tmp_path / "ckpt.jsonl"
+        records = [_ok("old"), _api_error("older"), _ok("kept"), _api_error("bad")]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+        sidecar = quarantine_error_records(path, {"bad"})
+
+        assert sidecar is not None
+        assert [r["bibtex_key"] for r in _read(sidecar)] == ["bad"]
+        # Everything else survives unchanged and in order, including an error
+        # record from an earlier run that this run did not touch.
+        assert [r["bibtex_key"] for r in _read(path)] == ["old", "older", "kept"]
+
+    def test_nothing_to_quarantine_leaves_the_file_alone(self, tmp_path: Path) -> None:
+        path = tmp_path / "ckpt.jsonl"
+        original = json.dumps(_ok("a")) + "\n"
+        path.write_text(original)
+        assert quarantine_error_records(path, {"a"}) is None
+        assert path.read_text() == original
+
+    def test_missing_checkpoint_is_safe(self, tmp_path: Path) -> None:
+        assert quarantine_error_records(tmp_path / "nope.jsonl", {"a"}) is None
+
+
+@pytest.mark.skipif(not _HAS_OPENAI, reason="scripts import the openai SDK")
+class TestAgenticScriptResume:
+    """``_read_done_keys`` must not treat a failed record as done."""
+
+    @staticmethod
+    def _load_script() -> Any:
+        script = (
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "parallel_agentic_btu_test_public.py"
+        )
+        spec = importlib.util.spec_from_file_location("parallel_agentic_btu", script)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_error_records_are_retried_not_skipped(self, tmp_path: Path) -> None:
+        module = self._load_script()
+        path = tmp_path / "ckpt.jsonl"
+        records = [_ok("good"), _api_error("failed")]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        assert module._read_done_keys(path) == {"good"}
+
+    def test_a_later_verdict_supersedes_an_earlier_failure(self, tmp_path: Path) -> None:
+        module = self._load_script()
+        path = tmp_path / "ckpt.jsonl"
+        records = [_api_error("k"), _ok("k")]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        assert module._read_done_keys(path) == {"k"}
+
+    def test_a_later_failure_reopens_an_earlier_verdict(self, tmp_path: Path) -> None:
+        module = self._load_script()
+        path = tmp_path / "ckpt.jsonl"
+        records = [_ok("k"), _api_error("k")]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        assert module._read_done_keys(path) == set()
+
+
+@pytest.mark.skipif(not _HAS_OPENAI, reason="the script imports the openai SDK")
+class TestResumeScriptWiring:
+    """End-to-end: the runner refuses an outage instead of checkpointing it."""
+
+    @staticmethod
+    def _load_script() -> Any:
+        script = (
+            Path(__file__).resolve().parent.parent / "scripts" / "parallel_resume_test_public.py"
+        )
+        spec = importlib.util.spec_from_file_location("parallel_resume_public", script)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @staticmethod
+    def _data_file(tmp_path: Path, n: int) -> Path:
+        path = tmp_path / "entries.jsonl"
+        path.write_text(
+            "\n".join(
+                json.dumps(
+                    {
+                        "bibtex_key": f"k{i}",
+                        "bibtex_type": "article",
+                        "fields": {"title": "T", "author": "A", "year": "2024"},
+                    }
+                )
+                for i in range(n)
+            )
+            + "\n"
+        )
+        return path
+
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        responder: Any,
+        n: int = 40,
+    ) -> tuple[Any, Path]:
+        module = self._load_script()
+        monkeypatch.setattr(module, "call_one", responder)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        checkpoint_dir = tmp_path / "ckpt"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "parallel_resume_test_public.py",
+                "--checkpoint-dir",
+                str(checkpoint_dir),
+                "--model",
+                "test/model",
+                "--jsonl-name",
+                "preds.jsonl",
+                "--data-file",
+                str(self._data_file(tmp_path, n)),
+                "--workers",
+                "2",
+            ],
+        )
+        return module, checkpoint_dir / "preds.jsonl"
+
+    def test_outage_run_exits_without_checkpointing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _always_fails(_client: Any, _model: str, entry: dict, *_a: Any) -> dict[str, Any]:
+            return _api_error(entry["bibtex_key"])
+
+        module, jsonl_path = self._run(monkeypatch, tmp_path, _always_fails)
+        with pytest.raises(SystemExit) as excinfo:
+            module.main()
+
+        assert "Refusing to checkpoint" in str(excinfo.value)
+        # No key was persisted, so every entry is retried by the next run.
+        assert _read(jsonl_path) == []
+
+    def test_healthy_run_checkpoints_normally(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _always_succeeds(_client: Any, _model: str, entry: dict, *_a: Any) -> dict[str, Any]:
+            return _ok(entry["bibtex_key"])
+
+        module, jsonl_path = self._run(monkeypatch, tmp_path, _always_succeeds)
+        module.main()
+        assert {r["bibtex_key"] for r in _read(jsonl_path)} == {f"k{i}" for i in range(40)}


### PR DESCRIPTION
## The incident

A screening run over 5,043 references from NeurIPS workshop submissions lost wifi partway through on 2026-09-02. `bibtex-check` records a DNS resolution failure as `not_found`, which is the same status that means "every database was asked and none has this paper". 2,500 references across 25 chunks came back 85 to 98 percent `not_found`, where a healthy chunk runs about 52% `verified` and 1 to 3 percent `not_found`. Every chunk was checkpointed and the exit code stayed 0 throughout.

HALLMARK did not notice, because `not_found` routes to Stage 2. The cascade forwarded the entire poisoned run to an expensive LLM diagnoser with no database evidence behind any entry, and in aggressive mode the residual uncertainty would have been promoted to fabrication verdicts. The run was caught because the ratio looked wrong, not because anything failed.

An absence-of-evidence status was being read as evidence of absence. This branch fixes the consuming side of that.

## What each commit changes

- **`b50176f`: batch-level sanity check in the bibtexupdater wrapper.** `assess_batch_health` scores every `bibtex-check` invocation and returns a frozen `BatchHealth` record counting `not_found`, transport failures and coverage-incomplete abstentions against the batch size. `run_bibtex_check_with_status` logs a warning when a batch trips the check; the new `run_bibtex_check_with_health` returns the record so a caller that persists results can act on it. `network_error` and `coverage_incomplete` join the status maps as abstentions (conservative VALID, confidence 0.30 and 0.45) and route to Stage 2, so the wrapper behaves correctly whether or not the upstream tool reports transport failures under their own status. The `run_bibtex_check_with_status` docstring now defines `not_found` as a positive claim about the lookup: every source consulted completed and returned no matching record. An entry where any source failed for a technical reason is an abstention, not an exhaustive miss.

- **`59257ec`: aggressive-mode gate and checkpoint guards.** `run_cascade_with_health` becomes the entry point and returns `(predictions, health)`, with `run_cascade` reduced to a thin wrapper over it. Aggressive promotion is skipped when `health.suspected_transport_failure` is set. New `hallmark/baselines/checkpoint_guard.py` carries `GuardedCheckpointWriter`, `RunHealthTracker`, `PoisonedBatchError` and `quarantine_error_records`, and both parallel runners are wired through it. The cascade's open-world default for an unmapped status is now documented rather than incidental, and warns once per distinct status instead of once per entry, so a drifted tool vocabulary stays visible without drowning out the batch-health warning.

- **`e09b70d`: docstring caveat on the published results.** Records which splits the aggressive guard provably cannot change, and states plainly where the bound is inconclusive.

## The threshold: 30% no-evidence on at least 20 entries

`suspected_transport_failure` is `total >= 20 and no_evidence_share > 0.30`, where `no_evidence` sums `not_found`, transport failures and coverage-incomplete records. Both constants live in `hallmark/baselines/bibtexupdater.py` with their derivation.

30% sits an order of magnitude above the healthy 1 to 3 percent `not_found` ceiling and far below the 85 to 98 percent the poisoned chunks showed, so it separates the two regimes with room on both sides: a genuinely fabrication-heavy bibliography stays under it, and no partial outage that matters lands beneath it. The 20-entry minimum keeps the share from firing on noise, since at the healthy 3% base rate 6 of 20 entries returning `not_found` has probability about 2e-5, which makes 20 the smallest batch where crossing 30% is decisive rather than unlucky.

## An error record never enters a checkpoint

Permanence was the expensive part of the incident. Both parallel runners append one JSONL record per entry and resume by skipping the keys already in that file, so a record written during an outage is trusted by every later run.

`GuardedCheckpointWriter` writes usable verdicts to the checkpoint and parks error records in a `<checkpoint>.rejected-<timestamp>.jsonl` sidecar instead. That is what makes a refused entry retryable: its key is absent from the checkpoint, so the next run re-runs it, while the failure itself stays on disk for inspection. `RunHealthTracker` folds each record into a running tally under a lock and raises `PoisonedBatchError` as soon as the run crosses the threshold, which cancels the pending futures and stops the run paying for calls that cannot produce evidence.

`parallel_resume_test_public.py` writes through the guard directly. `parallel_agentic_btu_test_public.py` cannot, because the verifier writes its own checkpoint line and the guard gets no chance to intercept it. That script instead stops treating error records as done in `_read_done_keys` (the rule `llm_agentic._load_checkpoint(skip_failed=True)` already applies), then calls `quarantine_error_records` to move this run's failed lines out of the checkpoint before exiting non-zero. The quarantine rewrites the checkpoint atomically through a temporary file and `os.replace`, keeping every line that is not a failed record for one of those keys unchanged and in order.

## Aggressive mode, and the bound that could not be closed

Aggressive mode forced every residual UNCERTAIN to `plausible_fabrication@0.55` unconditionally, so a batch whose Stage 1 reached no database at all came out as mass fabrication verdicts. Promotion is now skipped when the batch is flagged. The stance the mode implements is "treat DB lookups as gold standard", and during an outage there is no DB to stand on.

The guard is inert on a healthy batch by construction, since the flag is False whenever the no-evidence share stays under the threshold, and `test_healthy_aggressive_output_is_unchanged_by_the_guard` pins the healthy output as identical to unconditional promotion. It also cannot alter anything published: the paper's aggressive-mode numbers are frozen files in `data/v1.2/baseline_results/` that CI validates by checksum rather than re-running.

For a hypothetical re-run, the no-evidence statuses are a subset of what defers to Stage 2, so the frozen conservative runs' `cascade_breakdown_stats` bound the share from above. dev_public defers 266/1119 = 23.8% and test_public 222/831 = 26.7%, both below the threshold, so those splits' aggressive numbers cannot change.

stress_test is not settled, and this is a real gap. It defers 53/121 = 43.8%, which is an upper bound only, because deferrals also count `unconfirmed`, `partial_match`, `skipped` and `missing`, none of which enter the no-evidence share. The raw status dump that would settle it is not available in the repo: `bibtexupdater_raw_dev_public.jsonl` is an unfetched git-lfs pointer, and there is no stress_test raw dump at all. A re-run of the aggressive stress_test split is therefore the one place this guard could in principle produce different numbers. The frozen file is untouched either way.

## Relation to the bibtexupdater fix

This branch is the consuming side. The emitting side is a sibling branch in the `bibtexupdater` repo, `fix/source-outage-not-found` (`1991646`, `9993fc5`), which makes `not_found` require every consulted source to have completed. That branch is local and unpushed. Everything here is deliberately robust to it not landing: the batch-health check is a backstop for tool builds that report neither `network_error` nor `coverage_incomplete`, and both status names are accepted now so the wrapper needs no further change when they arrive.

## Verification

```
1142 passed, 2 skipped, 1 xfailed
```

`ruff format --check` reports 256 files already formatted and `ruff check` passes with `All checks passed!`. `mypy hallmark` reports `Success: no issues found in 58 source files`.

New tests cover the transport-status mapping, `assess_batch_health` at and around both thresholds, the cascade's poisoned and healthy paths, the aggressive suppression together with its healthy-batch equivalence, record classification and the tracker in `checkpoint_guard`, the guarded writer's sidecar behaviour, `quarantine_error_records`, and the resume wiring in both scripts.
