### PR TITLE
Pace Stage-2 source lookups against a per-service budget

### DIFF
--- a/hallmark/baselines/_agentic_tools.py
+++ b/hallmark/baselines/_agentic_tools.py
@@ -9,6 +9,10 @@ Tool set mirrors bibtex-updater's lookup sources:
 - search_crossref  — CrossRef title/author search
 - search_openalex  — OpenAlex polite pool
 - search_arxiv     — arXiv API
+
+Every outbound request passes through a process-wide, per-service rate limiter
+first (see "Per-service pacing" below), because the sources publish their limits
+per caller while Stage 2 calls them from several worker threads at once.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from __future__ import annotations
 import datetime as dt
 import email.utils
 import logging
+import math
 import os
 import re
 import threading
@@ -225,6 +230,160 @@ def _normalise(raw: dict) -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Per-service pacing
+# ---------------------------------------------------------------------------
+
+# Source APIs publish their limits per *caller*, not per process and not per thread, so
+# retry-on-429 is not pacing. Stage 2 runs 6-8 worker threads that all reach the sources
+# through this module, and each is free to fire the moment its last request returned. A
+# 2026-09 Stage-2 run measured what that costs on the tightest source: arXiv answered 21
+# requests and rejected 356, answering for roughly the first minute and returning 429
+# from then on, while CrossRef (93 of 93) and OpenAlex (100 of 101) stayed clean in the
+# same run. Stage 1 escapes this because it goes through ``bibtex-check``, which paces
+# per service itself; Stage 2 never invokes that CLI and so inherited none of it.
+#
+# Budgets are requests per minute, shared by every thread in the process. arXiv's
+# published ceiling is ~20/min per caller; the others sit under their source's
+# documented allowance. ``dblp``, ``openreview`` and ``openlibrary`` have no caller in
+# this module yet — they are listed so a tool added later inherits pacing rather than
+# repeating the defect.
+_DEFAULT_SERVICE_RATES: dict[str, float] = {
+    "arxiv": 20.0,
+    "crossref": 300.0,
+    "openalex": 150.0,
+    "dblp": 30.0,
+    "semanticscholar": 10.0,
+    "openreview": 30.0,
+    "openlibrary": 30.0,
+    # ``bibtex-check`` is a subprocess with its own outbound calls, paced internally by
+    # its ``--rate-limit`` flag. What this budget caps is how often we start one.
+    "bibtexupdater": 60.0,
+}
+
+# ``HALLMARK_ARXIV_RATE=10`` halves arXiv's budget, which is what a run sharded across
+# two processes needs: the published limit belongs to the caller, so the processes have
+# to divide it between them. Mirrors bibtex-updater's ``BIBTEX_ARXIV_RATE``.
+_RATE_ENV_TEMPLATE = "HALLMARK_{service}_RATE"
+
+
+class _ServiceRateLimiter:
+    """Space requests to one service evenly across every thread in the process.
+
+    Admissions are handed out one interval apart rather than as a refillable burst. The
+    measured arXiv rejections began after a burst, so a bucket that let eight workers
+    through at once would reproduce them.
+    """
+
+    def __init__(self, rate_per_minute: float) -> None:
+        self._lock = threading.Lock()
+        self._next_free = 0.0
+        self.rate_per_minute = 0.0
+        self._interval = 0.0
+        self.set_rate(rate_per_minute)
+
+    def set_rate(self, rate_per_minute: float) -> None:
+        """Adopt a new budget, keeping the pacing state already accrued.
+
+        A non-positive rate means "unpaced", which is what an unknown service gets.
+        """
+        with self._lock:
+            self.rate_per_minute = rate_per_minute
+            self._interval = 60.0 / rate_per_minute if rate_per_minute > 0.0 else 0.0
+
+    def acquire(self) -> float:
+        """Block until the next request to this service may go out.
+
+        Returns:
+            Seconds spent waiting, for logging and for tests.
+        """
+        with self._lock:
+            if self._interval <= 0.0:
+                return 0.0
+            now = time.monotonic()
+            start = max(now, self._next_free)
+            self._next_free = start + self._interval
+            wait = start - now
+        if wait > 0.0:
+            time.sleep(wait)
+        return wait
+
+
+# One limiter per service, shared by every worker thread. Guarded by its own lock.
+_rate_limiters: dict[str, _ServiceRateLimiter] = {}
+_rate_limiter_lock = threading.Lock()
+
+
+def _configured_rate(service: str) -> float:
+    """Return the requests-per-minute budget for *service*.
+
+    Reads ``HALLMARK_<SERVICE>_RATE`` and falls back to the built-in default when that
+    is unset, unparseable, non-finite, or not positive. A malformed knob must never take
+    a run down, so it is logged and ignored.
+
+    Args:
+        service: Service key, e.g. ``"arxiv"``.
+
+    Returns:
+        Requests per minute; ``0.0`` means the service is unpaced.
+    """
+    default = _DEFAULT_SERVICE_RATES.get(service, 0.0)
+    raw = os.environ.get(_RATE_ENV_TEMPLATE.format(service=service.upper()))
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring %s=%r: not a number; using %s requests/min for %s",
+            _RATE_ENV_TEMPLATE.format(service=service.upper()),
+            raw,
+            default,
+            service,
+        )
+        return default
+    if not math.isfinite(value) or value <= 0.0:
+        logger.warning(
+            "Ignoring %s=%r: not a positive finite rate; using %s requests/min for %s",
+            _RATE_ENV_TEMPLATE.format(service=service.upper()),
+            raw,
+            default,
+            service,
+        )
+        return default
+    return value
+
+
+def _limiter_for(service: str) -> _ServiceRateLimiter:
+    """Return the process-wide limiter for *service*, creating it on first use.
+
+    The configured rate is re-read on every call so an env change takes effect without a
+    restart; the limiter object itself is kept, so the budget stays shared.
+    """
+    rate = _configured_rate(service)
+    with _rate_limiter_lock:
+        limiter = _rate_limiters.get(service)
+        if limiter is None:
+            limiter = _ServiceRateLimiter(rate)
+            _rate_limiters[service] = limiter
+        elif limiter.rate_per_minute != rate:
+            limiter.set_rate(rate)
+    return limiter
+
+
+def _pace(service: str) -> float:
+    """Block until this process may issue another request to *service*.
+
+    Sits in front of the request, in addition to the retry-on-throttle behaviour behind
+    it: pacing keeps us inside the budget, retries handle the times we are told we are
+    outside it anyway.
+    """
+    waited = _limiter_for(service).acquire()
+    if waited > 0.0:
+        logger.debug("Paced %s for %.2fs", service, waited)
+    return waited
+
+
+# ---------------------------------------------------------------------------
 # resolve_doi
 # ---------------------------------------------------------------------------
 
@@ -252,6 +411,7 @@ def resolve_doi(doi: str) -> dict[str, str]:
     url = f"https://api.crossref.org/works/{urllib.parse.quote(normalized_doi, safe='/')}"
     headers = {"User-Agent": f"HALLMARK/1.0 (mailto:{_OPENALEX_MAILTO})"}
 
+    _pace("crossref")
     try:
         resp = httpx.get(url, headers=headers, timeout=10.0, follow_redirects=True)
     except httpx.RequestError as exc:
@@ -314,6 +474,7 @@ def search_crossref(query: str, limit: int = 5) -> list[dict[str, str]]:
     url = "https://api.crossref.org/works?" + urllib.parse.urlencode(params)
     headers = {"User-Agent": f"HALLMARK/1.0 (mailto:{_OPENALEX_MAILTO})"}
 
+    _pace("crossref")
     try:
         resp = httpx.get(url, headers=headers, timeout=15.0, follow_redirects=True)
     except httpx.RequestError as exc:
@@ -392,6 +553,7 @@ def search_openalex(query: str, limit: int = 5) -> list[dict[str, str]]:
             params["api_key"] = key
         url = "https://api.openalex.org/works?" + urllib.parse.urlencode(params)
 
+        _pace("openalex")
         try:
             resp = httpx.get(url, timeout=15.0, follow_redirects=True)
         except httpx.RequestError as exc:
@@ -481,6 +643,7 @@ def search_arxiv(query: str, limit: int = 5) -> list[dict[str, str]]:
     }
     url = "https://export.arxiv.org/api/query?" + urllib.parse.urlencode(params)
 
+    _pace("arxiv")
     try:
         resp = httpx.get(url, timeout=_ARXIV_TIMEOUT_SECONDS, follow_redirects=True)
     except httpx.RequestError as exc:
@@ -575,6 +738,7 @@ def search_semantic_scholar(query: str, limit: int = 5) -> list[dict[str, str]]:
 
     resp = None
     for headers in header_variants:
+        _pace("semanticscholar")
         try:
             resp = httpx.get(url, headers=headers, timeout=15.0, follow_redirects=True)
         except httpx.RequestError as exc:
@@ -670,6 +834,7 @@ def verify_with_bibtex_updater(bibtex: str) -> dict[str, str]:
         if s2_key:
             cmd.extend(["--s2-api-key", s2_key])
 
+        _pace("bibtexupdater")
         try:
             subprocess.run(cmd, capture_output=True, text=True, timeout=180.0, check=False)
         except subprocess.TimeoutExpired as exc:

--- a/tests/test_agentic_tools_rate_limit.py
+++ b/tests/test_agentic_tools_rate_limit.py
@@ -1,0 +1,250 @@
+"""Tests for the per-service rate limiter in `_agentic_tools`.
+
+Covers the failure mode measured in a 2026-09 Stage-2 run: arXiv answered 21 requests
+and rejected 356 while CrossRef and OpenAlex stayed clean, because the source publishes
+its limit per caller and Stage 2 called it from 6-8 worker threads that only ever
+backed off *after* being refused.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from hallmark.baselines import _agentic_tools
+from hallmark.baselines._agentic_tools import (
+    _DEFAULT_SERVICE_RATES,
+    _configured_rate,
+    _limiter_for,
+    _pace,
+    _rate_limiters,
+    _ServiceRateLimiter,
+)
+
+
+@pytest.fixture
+def fresh_limiters():
+    """Give each test an empty limiter registry, and leave one behind."""
+    _rate_limiters.clear()
+    yield
+    _rate_limiters.clear()
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Replace monotonic time and sleep so pacing is checked without waiting for it."""
+
+    class _Clock:
+        def __init__(self) -> None:
+            self.now = 1000.0
+            self.slept: list[float] = []
+
+        def monotonic(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            self.slept.append(seconds)
+            self.now += seconds
+
+    clock = _Clock()
+    monkeypatch.setattr(_agentic_tools.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(_agentic_tools.time, "sleep", clock.sleep)
+    return clock
+
+
+class TestAdmissionRate:
+    def test_first_request_is_not_delayed(self, fake_clock):
+        limiter = _ServiceRateLimiter(20.0)
+        assert limiter.acquire() == 0.0
+        assert fake_clock.slept == []
+
+    def test_admissions_are_one_interval_apart(self, fake_clock):
+        """20/min means a request every 3s, which is what arXiv's ceiling buys."""
+        limiter = _ServiceRateLimiter(20.0)
+        waits = [limiter.acquire() for _ in range(4)]
+        assert waits == [0.0, 3.0, 3.0, 3.0]
+
+    def test_time_already_spent_counts_against_the_interval(self, fake_clock):
+        """A slow request pays part of its own pacing; only the remainder is waited out."""
+        limiter = _ServiceRateLimiter(20.0)
+        limiter.acquire()
+        fake_clock.now += 2.0
+        assert limiter.acquire() == pytest.approx(1.0)
+
+    def test_an_idle_gap_does_not_accrue_a_burst(self, fake_clock):
+        """Waiting a minute does not buy twenty requests at once — the next one is free,
+        the one after it still waits a full interval."""
+        limiter = _ServiceRateLimiter(20.0)
+        limiter.acquire()
+        fake_clock.now += 60.0
+        assert limiter.acquire() == 0.0
+        assert limiter.acquire() == 3.0
+
+    @pytest.mark.parametrize("rate", [0.0, -5.0])
+    def test_a_non_positive_rate_means_unpaced(self, fake_clock, rate):
+        limiter = _ServiceRateLimiter(rate)
+        assert [limiter.acquire() for _ in range(5)] == [0.0] * 5
+
+    def test_set_rate_keeps_the_pacing_already_accrued(self, fake_clock):
+        """Re-reading the env mid-run must not hand out a free request."""
+        limiter = _ServiceRateLimiter(20.0)
+        limiter.acquire()
+        limiter.set_rate(60.0)
+        assert limiter.acquire() == 3.0  # the interval booked under the old rate
+        assert limiter.acquire() == 1.0  # then the new one
+
+
+class TestBudgetIsSharedAcrossThreads:
+    def test_two_threads_on_one_service_share_one_budget(self, fresh_limiters, monkeypatch):
+        """The defect: 6-8 workers each pacing themselves is 6-8x the caller's budget.
+
+        Runs on the real clock, because the threads would race on a fake one. 600/min
+        keeps it to half a second of wall time while still discriminating: six
+        admissions through one budget take five intervals, where two independent
+        budgets would take two and a half.
+        """
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "600")
+        interval = 0.1
+        barrier = threading.Barrier(2)
+
+        def worker() -> None:
+            barrier.wait()
+            for _ in range(3):
+                _pace("arxiv")
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        started = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        elapsed = time.monotonic() - started
+
+        # Five intervals for six admissions, minus a margin for clock granularity.
+        assert elapsed >= 5 * interval * 0.95
+        assert elapsed < 5 * interval + 2.0
+
+    def test_the_same_service_resolves_to_the_same_limiter(self, fresh_limiters):
+        assert _limiter_for("arxiv") is _limiter_for("arxiv")
+
+    def test_different_services_have_separate_budgets(self, fresh_limiters, fake_clock):
+        """arXiv being paced must not slow CrossRef, which was clean in the same run."""
+        for _ in range(3):
+            _pace("arxiv")
+        assert _pace("crossref") == 0.0
+
+
+class TestEnvOverride:
+    def test_default_applies_when_unset(self, fresh_limiters, monkeypatch):
+        monkeypatch.delenv("HALLMARK_ARXIV_RATE", raising=False)
+        assert _configured_rate("arxiv") == _DEFAULT_SERVICE_RATES["arxiv"] == 20.0
+
+    def test_env_override_is_honoured(self, fresh_limiters, monkeypatch):
+        """A run sharded across two processes halves each process's share."""
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "10")
+        assert _configured_rate("arxiv") == 10.0
+        assert _limiter_for("arxiv").rate_per_minute == 10.0
+
+    def test_override_reaches_the_pacing(self, fresh_limiters, fake_clock, monkeypatch):
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "10")
+        _pace("arxiv")
+        assert _pace("arxiv") == 6.0
+
+    def test_every_service_has_its_own_knob(self, fresh_limiters, monkeypatch):
+        for service, default in _DEFAULT_SERVICE_RATES.items():
+            monkeypatch.setenv(f"HALLMARK_{service.upper()}_RATE", "7")
+            assert _configured_rate(service) == 7.0
+            monkeypatch.delenv(f"HALLMARK_{service.upper()}_RATE")
+            assert _configured_rate(service) == default
+
+    def test_a_change_mid_run_updates_the_shared_limiter(self, fresh_limiters, monkeypatch):
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "10")
+        limiter = _limiter_for("arxiv")
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "5")
+        assert _limiter_for("arxiv") is limiter
+        assert limiter.rate_per_minute == 5.0
+
+    def test_an_unknown_service_is_unpaced(self, fresh_limiters, fake_clock):
+        assert _configured_rate("nowhere") == 0.0
+        assert [_pace("nowhere") for _ in range(5)] == [0.0] * 5
+
+
+class TestBadEnvValueDoesNotCrash:
+    @pytest.mark.parametrize(
+        "value", ["", "   ", "twenty", "20/min", "nan", "inf", "-inf", "0", "-3"]
+    )
+    def test_unusable_values_fall_back_to_the_default(self, fresh_limiters, monkeypatch, value):
+        """A mistyped knob must cost the run its override, never the run."""
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", value)
+        assert _configured_rate("arxiv") == 20.0
+
+    def test_a_bad_value_still_paces(self, fresh_limiters, fake_clock, monkeypatch):
+        monkeypatch.setenv("HALLMARK_ARXIV_RATE", "twenty")
+        _pace("arxiv")
+        assert _pace("arxiv") == 3.0
+
+    def test_a_fractional_rate_is_accepted(self, fresh_limiters, monkeypatch):
+        """Sharding four ways over a 10/min source lands on a non-integer share."""
+        monkeypatch.setenv("HALLMARK_SEMANTICSCHOLAR_RATE", "2.5")
+        assert _configured_rate("semanticscholar") == 2.5
+
+
+class _StubResponse:
+    """Minimal stand-in for an httpx.Response holding an empty result set."""
+
+    def __init__(self, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = 200
+        self.headers: dict[str, str] = {}
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+_EMPTY_ATOM = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+
+# One canned empty response per source, keyed by the tool that fetches it.
+_TOOL_CASES = [
+    ("resolve_doi", "crossref", {"message": {}}, "", {"doi": "10.1234/abc"}),
+    ("search_crossref", "crossref", {"message": {"items": []}}, "", {"query": "q"}),
+    ("search_openalex", "openalex", {"results": []}, "", {"query": "q"}),
+    ("search_arxiv", "arxiv", {}, _EMPTY_ATOM, {"query": "q"}),
+    ("search_semantic_scholar", "semanticscholar", {"data": []}, "", {"query": "q"}),
+]
+
+
+class TestEveryRequestIsPaced:
+    """Each source-calling tool must pass through the limiter before it fetches.
+
+    This is the regression guard: the defect was one tool reaching a source with no
+    pacing at all, and a tool added later would repeat it silently.
+    """
+
+    @pytest.mark.parametrize(
+        ("tool_name", "service", "payload", "text", "kwargs"),
+        _TOOL_CASES,
+        ids=[case[0] for case in _TOOL_CASES],
+    )
+    def test_tool_paces_its_service(
+        self, fresh_limiters, monkeypatch, tool_name, service, payload, text, kwargs
+    ):
+        import httpx
+
+        paced: list[str] = []
+        monkeypatch.setattr(_agentic_tools, "_pace", lambda name: paced.append(name) or 0.0)
+        monkeypatch.setattr(
+            httpx, "get", lambda *a, **kw: _StubResponse(payload, text), raising=True
+        )
+        monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+        monkeypatch.delenv("S2_API_KEY", raising=False)
+
+        getattr(_agentic_tools, tool_name)(**kwargs)
+        assert paced == [service]
+
+    def test_every_source_tool_is_covered(self):
+        """Fails when a tool is added to the registry without a pacing case here."""
+        covered = {case[0] for case in _TOOL_CASES} | {"verify_with_bibtex_updater"}
+        assert set(_agentic_tools.TOOL_REGISTRY) == covered


### PR DESCRIPTION
Every source-calling tool in `_agentic_tools.py` built its own client per call and retried on throttle, with no pacing. N workers therefore each took an unbounded share of a shared per-IP budget, and the agentic path starved its own sources.

This adds a process-wide, thread-safe per-service limiter shared across workers, overridable per source via `HALLMARK_<SERVICE>_RATE` so a sharded run can divide the caller budget. All five source tools were unpaced, not only `search_arxiv`.

## Measured

Same 119 entries, same model, same prompt, same code — only pacing differed:

| | arXiv calls answered | flags that cleared on re-adjudication |
|---|---|---|
| unpaced, 8 workers | 21 of 377 | 12% |
| paced, 6 workers | 101 of 101 | 24% |

Source availability is worth a factor of two on the outcome. That is the part that matters beyond the fix itself: an agentic verdict is a function of network conditions at run time, so a benchmark score is too.

The failure was silent, which is why it went unnoticed. A tool 429s, retries to exhaustion, returns empty; the model reads empty as "this work does not exist" and emits HALLUCINATED at 0.95-0.98 confidence. Nothing raises and nothing in the output records that a source never answered. In an earlier pass over the same corpus arXiv answered 0 of 317 calls and the run reported verdicts normally.

## Why this blocks re-running the baselines

Every published agentic number predates this commit, so all of them were produced under self-inflicted starvation whose size scales with worker count. Agentic baselines should be re-run under stated per-service budgets, and the budget used should be recorded alongside the score.

## Follow-on, not in this PR

The deeper fix is a tri-state contract on every source tool — found / not-found / unavailable — so a checker can be *required* to abstain when a source it needed was unavailable. Pacing reduces how often the conflation is reached; it does not remove it. Related: #36.

## Tests

`tests/test_agentic_tools_rate_limit.py`, 250 lines, covering the shared-limiter behaviour across threads and the env overrides.

Authored by another session on this machine; pushed and opened here because the commit existed only on a local branch inside a vendored checkout, with no remote copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fms8Y1kBGbM8fxGMnZYCaU