### PR TITLE
Ground truth must not inherit corruption from the indexes it queries

### DIFF
--- a/notes/eval-hardening-2026-09-04.md
+++ b/notes/eval-hardening-2026-09-04.md
@@ -249,6 +249,52 @@ caught by someone else or by re-measuring.
   satellite-marker branch rather than the one under test.
 - Wrote an exemption-staleness test that was itself population-dependent — the
   exact defect the gate was split apart to stop making. CI caught it.
+- Wrote my harc tests at `_run_harc_batches`, the level I was editing, when the
+  damage lands one level up in `run_with_prescreening`. They would have passed
+  while the defect survived. Caught by the session porting them.
+- Nearly reported nine `hybrid_fabrication` entries as mislabelled, having
+  compared titles by substring containment — which a *modified* title trivially
+  satisfies. Checking authors, as the type definition requires, showed all nine
+  correct. A looser test would have produced a false accusation against the
+  benchmark's own labels.
+
+## The taxonomy result (issue #36)
+
+Measured after the fixes above, and it is the largest single finding of the day.
+Scoring every tool three ways — as shipped, with the four real-paper modes
+(`wrong_venue`, `preprint_as_published`, `partial_author_list`,
+`arxiv_version_mismatch`) removed from the scored set, and with them as negatives
+— **the ranking is not stable and the top changes identity.** On `test_public`
+14 of 21 tools move under the first fold and 17 of 21 under the second;
+`dev_public` agrees. `cascade_db_diagnosis` leads as shipped at MCC 0.897;
+`bibtexupdater` takes first when they are scored as false accusations.
+
+The mechanism, verified independently from the committed `per_type_metrics`:
+those four modes are **26.8% of the positive class** on `test_public` (139 of
+519) and **27.0% of the leading cascade's detections** (139 of 514), every one of
+which it converts — DR 1.000. The spread across tools is the part worth keeping:
+bibtexupdater 20.0%, Sonnet 4.6 23.2%, `doi_only` 9.1%, median DR 0.755 across 21
+tools. A tool's rank depends heavily on how much of its credit comes from
+flagging real papers described wrongly, and nothing in the reporting shows it.
+
+`stress_test` is worse: 75 of its 122 entries (61.5%) are real-paper modes, and
+**100% of the cascade's misses on that split are on them** — `merged_citation`
+sits at DR 1.000 across all 46 entries. So a stress-test detection rate is mostly
+a measure of catching correct citations described imprecisely.
+
+`hybrid_fabrication` does **not** fold with them, and folding it alone moves
+nothing (Kendall tau 1.000, no tool changes position). The distinction is that
+the other four mean the work exists and the entry describes it inaccurately,
+while this one means the entry claims one work and the DOI resolves to another —
+a fabrication if the index is right, a correct citation if the index is corrupt.
+
+Its population is sound: all 74 entries are generated (53 adversarial, 19
+perturbation, 2 LLM), none resolved from an index, and all 35 of the resolvable
+DOIs are consistent with the type — 26 to a clearly different paper, 9 to a
+similar title with zero author overlap. The exposure is entirely prospective.
+
+**Ruled: report the ablation, defer the relabel.** The instability goes in the
+paper as a stated result rather than being settled by relabelling five splits.
 
 ## Open
 

--- a/tests/test_corrupt_index_records_do_not_relabel.py
+++ b/tests/test_corrupt_index_records_do_not_relabel.py
@@ -1,0 +1,169 @@
+"""Ground truth must not inherit corruption from the indexes it was built against.
+
+OpenAlex serves records carrying the **correct DOI and the correct author list**
+under a **wrong title**. Three were reproduced at source:
+
+===========================  ====================  ==========================================
+identifier                   really                served as
+===========================  ====================  ==========================================
+``10.48550/arxiv.2307.16789``  ToolLLM              "Counterfactually Auditable Lifecycle
+                                                    Certification for Autonomous Agents"
+``10.48550/arxiv.2212.08073``  Constitutional AI    "Affective Coherence Monitoring for
+                                                    Transformer-Based Language Models"
+``10.48550/arxiv.2106.09685``  LoRA                 "LoRA Fine-Tuning of a 3B Code LLM for
+                                                    Algorithmic Efficiency"
+===========================  ====================  ==========================================
+
+That is exactly HALLMARK's ``hybrid_fabrication`` signature — a real DOI whose
+other metadata does not match the DOI target — produced by a defective index
+record rather than by a bad citation. On a corpus of 5,043 real references the
+signature came from corruption three times for every one genuine citation error.
+
+**The risk is live, not theoretical.** ``data/v1.2/dev_public.jsonl`` contains
+``db9d82ff3f94``, the real Constitutional AI paper, correctly labelled VALID. A
+relabelling pass that queries OpenAlex for its DOI — ``relabel_ground_truth.py``
+does exactly this kind of resolution — would receive the wrong title with the
+right authors and could reasonably conclude the entry is a hybrid fabrication,
+converting a correct VALID entry into a false accusation. Nothing else would
+notice: the DOI resolves, the authors match, and the title disagreement is the
+whole basis of the type.
+
+It is also a shape synthetic perturbation cannot generate. The benchmark's own
+generators build hybrid fabrications by corrupting metadata deliberately; an
+index serving right authors under a wrong title is a defect of the source, and no
+amount of perturbing real entries produces it.
+
+Payloads are pinned from bibtex-updater's recorded fixtures (commit ``8e3c8d1``)
+rather than fetched. If OpenAlex repairs these records a fetching test would
+start passing for the wrong reason, which is the failure mode this whole area
+keeps producing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: arXiv id -> (what the work really is, what OpenAlex served instead).
+#: Recorded 2026-09-04. Not fetched at test time, deliberately.
+CORRUPT_INDEX_RECORDS: dict[str, tuple[str, str]] = {
+    "2307.16789": (
+        "ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs",
+        "Counterfactually Auditable Lifecycle Certification for Autonomous Agents",
+    ),
+    "2212.08073": (
+        "Constitutional AI: Harmlessness from AI Feedback",
+        "Affective Coherence Monitoring for Transformer-Based Language Models",
+    ),
+    "2106.09685": (
+        "LoRA: Low-Rank Adaptation of Large Language Models",
+        "LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency",
+    ),
+}
+
+_SPLITS = (
+    "data/v1.2/dev_public.jsonl",
+    "data/v1.2/test_public.jsonl",
+    "data/v1.2/test_crossdomain.jsonl",
+    "data/v1.2/stress_test.jsonl",
+    "data/hidden/test_hidden.jsonl",
+)
+
+
+def _entries_touching_corrupt_records() -> list[tuple[str, dict]]:
+    """Every split entry whose fields mention one of the three identifiers."""
+    found: list[tuple[str, dict]] = []
+    for rel in _SPLITS:
+        path = _REPO_ROOT / rel
+        if not path.is_file():  # data/hidden/ is gitignored
+            continue
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            blob = json.dumps(entry.get("fields") or {})
+            for arxiv_id in CORRUPT_INDEX_RECORDS:
+                if arxiv_id in blob:
+                    found.append((rel, entry))
+                    break
+    return found
+
+
+def _normalise(title: str) -> str:
+    return "".join(c for c in title.lower() if c.isalnum())
+
+
+def test_no_entry_is_labelled_from_the_corrupt_title():
+    """An entry citing one of these works must be judged on what it really is.
+
+    If a relabelling pass ever adopts the served title, the entry's own title
+    stops matching and it becomes a hybrid fabrication. This asserts the shipped
+    labels still describe the real work.
+    """
+    offenders: list[str] = []
+    for rel, entry in _entries_touching_corrupt_records():
+        title = _normalise((entry.get("fields") or {}).get("title", ""))
+        for _arxiv_id, (_real, served) in CORRUPT_INDEX_RECORDS.items():
+            if _normalise(served) in title or title in _normalise(served):
+                offenders.append(
+                    f"{rel}:{entry.get('bibtex_key')} carries the CORRUPT title "
+                    f"{served!r} — the ground truth has absorbed an index defect"
+                )
+    assert not offenders, "\n  ".join(offenders)
+
+
+def test_a_correctly_cited_work_is_not_flagged_as_hybrid_fabrication():
+    """The specific reversal this guards against.
+
+    ``hybrid_fabrication`` means a real DOI whose other metadata does not match
+    the DOI target. A corrupt index record produces that signature from a
+    perfectly correct citation, so an entry citing one of these works must not
+    carry the type unless something other than the index says so.
+    """
+    offenders: list[str] = []
+    for rel, entry in _entries_touching_corrupt_records():
+        if entry.get("hallucination_type") == "hybrid_fabrication":
+            offenders.append(
+                f"{rel}:{entry.get('bibtex_key')} is typed hybrid_fabrication while "
+                "citing a work whose OpenAlex record is known corrupt. Verify against a "
+                "source outside the index before trusting that label."
+            )
+    assert not offenders, "\n  ".join(offenders)
+
+
+def test_the_known_constitutional_ai_entry_is_still_valid():
+    """Pins the one live instance so a relabel cannot flip it silently.
+
+    ``dev_public`` carries the real Constitutional AI paper. Its OpenAlex record
+    serves the right authors under the wrong title, which is the exact input that
+    would make a resolver conclude the citation is fabricated.
+    """
+    matches = [
+        entry
+        for rel, entry in _entries_touching_corrupt_records()
+        if "2212.08073" in json.dumps(entry.get("fields") or {})
+    ]
+    if not matches:
+        pytest.skip("Constitutional AI entry not present in the available splits")
+    for entry in matches:
+        assert entry.get("label") == "VALID", (
+            f"{entry.get('bibtex_key')} is a correct citation of a real paper and must "
+            f"stay VALID; it is now {entry.get('label')} "
+            f"({entry.get('hallucination_type')}). OpenAlex serves this DOI under the "
+            "title 'Affective Coherence Monitoring for Transformer-Based Language "
+            "Models' with the right author list — if a relabelling pass trusted that, "
+            "this is what the damage looks like."
+        )
+
+
+def test_the_register_is_not_empty():
+    """Otherwise every assertion above passes vacuously."""
+    assert CORRUPT_INDEX_RECORDS
+    assert _entries_touching_corrupt_records(), (
+        "no split entry cites any of the three records — the guard is inert. "
+        "Either the data changed or the identifiers are wrong."
+    )

--- a/tests/test_results_provenance.py
+++ b/tests/test_results_provenance.py
@@ -121,6 +121,14 @@ def _is_null_run(data: dict) -> bool:
     CLI was missing: the wrapper returns all-VALID for every entry and the
     harness scores it like any other result. Four such files shipped as the
     pre-screening ablations for bibtexupdater and harc.
+
+    **The conjunction is load-bearing, not belt-and-braces.** ``mean_api_calls``
+    of 0.0 is uninformative rather than diagnostic for every HaRC row, because
+    that wrapper never records API calls at all:
+    ``harc_with_s2key_dev_public.json`` reports 0.0 while being a real
+    evaluation at full coverage with DR 0.209. Requiring a zero detection rate
+    AND a zero false-positive rate alongside it is the only thing standing
+    between this guard and a genuine result.
     """
     return (
         data.get("detection_rate") == 0.0


### PR DESCRIPTION
Follow-on to #39, which is merged. One test file plus a docstring.

## The defect

OpenAlex serves records carrying the **correct DOI** and the **correct author list** under a **wrong title**. Three reproduced at source:

| identifier | really | served as |
|---|---|---|
| `10.48550/arxiv.2307.16789` | ToolLLM | "Counterfactually Auditable Lifecycle Certification for Autonomous Agents" |
| `10.48550/arxiv.2212.08073` | Constitutional AI | "Affective Coherence Monitoring for Transformer-Based Language Models" |
| `10.48550/arxiv.2106.09685` | LoRA | "LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency" |

That is exactly HALLMARK's `hybrid_fabrication` signature — a real DOI whose other metadata does not match the DOI target — produced by a defective index record rather than by a bad citation. On a corpus of 5,043 real references the signature came from corruption **three times for every one genuine citation error**.

## Why it matters here

`data/v1.2/dev_public.jsonl` contains `db9d82ff3f94`, the real Constitutional AI paper, correctly labelled VALID. `scripts/relabel_ground_truth.py` does exactly this kind of resolution, so a relabelling pass would receive the wrong title with the right authors and could reasonably conclude the entry is a hybrid fabrication — turning a correct citation into a false accusation.

Nothing else would catch it: the DOI resolves, the authors match, and the title disagreement *is* the type. Verified by injecting that relabel into `dev_public`; two assertions fail naming the entry, and the message spells out what the damage looks like.

It is also a shape synthetic perturbation cannot generate. The generators build hybrid fabrications by corrupting metadata deliberately; an index serving the right authors under a wrong title is a defect of the source.

## Notes

Payloads are pinned from bibtex-updater's recorded fixtures (`8e3c8d1`) rather than fetched. If OpenAlex repairs these records a fetching test would start passing for the wrong reason — the failure mode this area keeps producing.

Also documents why `_is_null_run`'s conjunction is load-bearing rather than defensive: `mean_api_calls` of 0.0 is uninformative for every HaRC row, because that wrapper never records API calls. `harc_with_s2key_dev_public.json` reports 0.0 while being a real evaluation at full coverage with DR 0.209, so the zero detection rate and zero FPR alongside it are the only things standing between the guard and a genuine result.

Suite: 1,219 passing, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp