### PR TITLE
A run bibtex-check disowned was still being scored

### DIFF
--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -53,6 +54,17 @@ from hallmark.baselines.common import entries_to_bib, fallback_predictions, run_
 from hallmark.dataset.schema import BlindEntry, Prediction
 
 logger = logging.getLogger(__name__)
+
+
+class SourceOutageError(RuntimeError):
+    """bibtex-check reported that its sources went dark during the run.
+
+    Raised rather than returned so the run cannot be silently scored. The tool
+    prints "Treat this run as incomplete and discard its could-not-verify
+    verdicts"; before this existed, the wrapper logged that and scored the run
+    anyway.
+    """
+
 
 # Map bibtex-check status to HALLMARK label.
 # Statuses come from bibtex-updater's FactCheckStatus enum.
@@ -315,6 +327,60 @@ BIBTEX_CHECK_BIN_ENV = "HALLMARK_BIBTEX_CHECK_BIN"
 #: Pacing is therefore part of the run condition and belongs on the same
 #: footing as the binary: settable, and recorded in the log.
 BIBTEX_CHECK_RATE_ENV = "HALLMARK_BIBTEX_CHECK_RATE_LIMIT"
+
+#: bibtex-check's exit code for "sources went dark during this run".
+#:
+#: Its own words, printed alongside it: "Treat this run as incomplete and
+#: discard its could-not-verify verdicts." The wrapper used to log that at ERROR
+#: and then parse the output and return predictions anyway, so a run the tool
+#: had disowned became a scored result. On 2026-09-04, with dblp.org
+#: unreachable, that produced bibtexupdater_dev_public.json at DR 0.8185 /
+#: FPR 0.0312 / coverage 1.0000 from a run where 25.5% of entries never got a
+#: complete set of source lookups.
+#:
+#: A source that never answered is not evidence a reference is absent, so those
+#: entries' abstentions carry no information -- and nothing downstream could
+#: tell them from real ones.
+EXIT_SOURCE_OUTAGE = 5
+
+#: Set to "1" to score a run bibtex-check reported as a source outage anyway.
+#: Deliberately awkward: the numbers are not comparable to a healthy run.
+ALLOW_OUTAGE_ENV = "HALLMARK_ALLOW_SOURCE_OUTAGE"
+
+#: "285 of 1119 entries (25.5%) had at least one source lookup that did not
+#: complete: dblp (275), openalex (26)"
+_OUTAGE_RE = re.compile(
+    r"(\d+) of (\d+) entries \(([\d.]+)%\) had at least one source lookup "
+    r"that did not complete:\s*([^\n.]*)"
+)
+
+
+def parse_source_condition(output: str) -> dict[str, object] | None:
+    """Extract bibtex-check's own source-availability report, if it made one.
+
+    Availability moves outcomes, so it belongs in the result beside the numbers
+    rather than only in a log a reader never sees.
+    """
+    # The final summary line wins: bibtex-check may report progressively.
+    matches = list(_OUTAGE_RE.finditer(output))
+    if not matches:
+        return None
+    match = matches[-1]
+    per_source: dict[str, int] = {}
+    for chunk in match.group(4).split(","):
+        chunk = chunk.strip()
+        if "(" in chunk and chunk.endswith(")"):
+            name, _, count = chunk.partition("(")
+            try:
+                per_source[name.strip()] = int(count.rstrip(")"))
+            except ValueError:
+                continue
+    return {
+        "entries_with_incomplete_lookups": int(match.group(1)),
+        "entries_total": int(match.group(2)),
+        "incomplete_fraction": float(match.group(3)) / 100.0,
+        "per_source_failures": per_source,
+    }
 
 
 def resolve_bibtex_check_rate_limit(default: int) -> int:
@@ -706,7 +772,35 @@ def _run_bibtex_check_subprocess(
                 text=True,
                 timeout=timeout,
             )
-            if result.returncode not in (0, 2, 4):
+            if result.returncode == EXIT_SOURCE_OUTAGE:
+                condition = parse_source_condition(result.stdout + result.stderr)
+                detail = ""
+                if condition:
+                    detail = (
+                        f" {condition['entries_with_incomplete_lookups']} of "
+                        f"{condition['entries_total']} entries "
+                        f"({condition['incomplete_fraction']:.1%}) had an incomplete "
+                        f"lookup: {condition['per_source_failures']}."
+                    )
+                if os.environ.get(ALLOW_OUTAGE_ENV) == "1":
+                    logger.error(
+                        "bibtex-check reported a SOURCE OUTAGE (exit %d).%s "
+                        "Scoring it anyway because %s=1 -- these numbers are NOT "
+                        "comparable to a healthy run.",
+                        EXIT_SOURCE_OUTAGE,
+                        detail,
+                        ALLOW_OUTAGE_ENV,
+                    )
+                else:
+                    raise SourceOutageError(
+                        f"bibtex-check reported a source outage (exit "
+                        f"{EXIT_SOURCE_OUTAGE}) and asked for the run to be "
+                        f"discarded.{detail} A source that never answered is not "
+                        "evidence a reference is absent, so this run cannot be "
+                        "scored. Re-run when the sources are reachable, or set "
+                        f"{ALLOW_OUTAGE_ENV}=1 to score it regardless."
+                    )
+            elif result.returncode not in (0, 2, 4):
                 logger.error(f"bibtex-check failed (exit {result.returncode}): {result.stderr}")
         except FileNotFoundError:
             logger.error("bibtex-check not found. Install with: pipx install bibtex-updater")

--- a/hallmark/cli.py
+++ b/hallmark/cli.py
@@ -540,6 +540,24 @@ def _stamp_provenance(result: EvaluationResult, args: argparse.Namespace) -> Non
 
     result.run_timestamp = datetime.now(timezone.utc).isoformat()
 
+    # Which external build answered. The field existed and nothing filled it, so
+    # the first ablation run after adding it still wrote tool_version: None --
+    # for the very tool whose PATH-resolved version motivated the field.
+    baseline = getattr(args, "baseline", None) or ""
+    if "bibtexupdater" in baseline or "cascade" in baseline or "btu" in baseline:
+        try:
+            from hallmark.baselines.bibtexupdater import (
+                bibtex_check_version,
+                resolve_bibtex_check_bin,
+            )
+
+            binary = resolve_bibtex_check_bin()
+            version = bibtex_check_version(binary)
+            if version:
+                result.tool_version = f"bibtex-updater {version}"
+        except (ImportError, OSError) as exc:  # pragma: no cover - best effort
+            logging.debug("Could not probe bibtex-check version: %s", exc)
+
     split = getattr(args, "split", None)
     if not split:
         return

--- a/notes/eval-hardening-2026-09-04.md
+++ b/notes/eval-hardening-2026-09-04.md
@@ -252,6 +252,10 @@ caught by someone else or by re-measuring.
 - Wrote my harc tests at `_run_harc_batches`, the level I was editing, when the
   damage lands one level up in `run_with_prescreening`. They would have passed
   while the defect survived. Caught by the session porting them.
+- Proposed that the four-mode surface leak was a venue-presence sampling
+  artefact. It is not: conditioning the negatives the same way leaves the
+  detection rate unmoved. The measurement behind the hypothesis was right and
+  the inference from it was wrong.
 - Nearly reported nine `hybrid_fabrication` entries as mislabelled, having
   compared titles by substring containment — which a *modified* title trivially
   satisfies. Checking authors, as the type definition requires, showed all nine
@@ -292,6 +296,32 @@ Its population is sound: all 74 entries are generated (53 adversarial, 19
 perturbation, 2 LLM), none resolved from an index, and all 35 of the resolvable
 DOIs are consistent with the type — 26 to a clearly different paper, 9 to a
 similar title with zero author overlap. The exposure is entirely prospective.
+
+### The shortcut control, and a hypothesis of mine that was wrong
+
+A classifier using only surface features — field presence, string lengths,
+author count, entry type, year, no lookups and no semantics — separates the four
+real-paper modes from VALID entries at **DR 0.468 on dev and 0.388 on test**,
+against a majority baseline of 0.000. So a meaningful share of the cascade's
+1.000 on those modes could be read off the entry without verifying anything.
+Real leakage, and worth reporting as a benchmark limitation — but it is not
+1.000, so the cascade's score is not purely the model reading the generator.
+
+`venue_chars` carries 0.38 of the feature importance, which is a strange thing
+for a raw string length to do, so I checked what it was. Median venue length is
+identical at 4 across every group, but **VALID entries are 4.3% venueless and
+the four modes are 0–2%** — a sampling artefact rather than a property of
+citations, since all four modes need a venue to manipulate and an entry lacking
+one can never be selected into them.
+
+**That hypothesis is wrong, and it was the cheap-fix one.** Conditioning the
+negative class the same way the positives are conditioned moves nothing:
+dev 513 → 491 negatives leaves DR at 0.468, test 312 → 299 takes it from 0.388
+to 0.403. Disconfirmed by the session that owns the control and reproduced here.
+
+The difference matters for what the paper says. "We sampled badly" is fixable in
+the next release; "the perturbation itself is detectable" is a design question
+about the four modes. It is the second.
 
 **Ruled: report the ablation, defer the relabel.** The instability goes in the
 paper as a stated result rather than being settled by relabelling five splits.

--- a/tests/test_source_outage_is_not_scored.py
+++ b/tests/test_source_outage_is_not_scored.py
@@ -1,0 +1,83 @@
+"""A run the tool disowned must not become a scored result.
+
+``bibtex-check`` exits 5 when failed lookups touched at least 10% of entries,
+and prints alongside it: *"Treat this run as incomplete and discard its
+could-not-verify verdicts."* The wrapper logged that at ERROR and then parsed
+the output and returned predictions anyway.
+
+It happened for real on 2026-09-04. dblp.org was unreachable — every request
+timing out, homepage included — and the ablation's first arm produced
+``bibtexupdater_dev_public.json`` at DR 0.8185, FPR 0.0312 and **coverage
+1.0000**, from a run where 285 of 1,119 entries (25.5%) never got a complete set
+of source lookups. Nothing downstream could tell those abstentions from real
+ones, and the result recorded full coverage.
+
+This is the same defect as an API failure written into a prediction file as a
+verdict, and as a timed-out batch scoring zero: a tool reported a problem
+honestly and the consumer discarded the report. It is the fourth instance found
+in one day, which is why the fix records the condition rather than only refusing
+— availability moves outcomes, so it belongs beside the numbers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hallmark.baselines.bibtexupdater import (
+    EXIT_SOURCE_OUTAGE,
+    parse_source_condition,
+)
+
+#: bibtex-check's actual output from the 2026-09-04 dblp outage.
+REAL_OUTAGE_OUTPUT = """\
+INFO: Loaded 1119 entries from dev_public
+WARNING: 285 of 1119 entries (25.5%) had at least one source lookup that did not \
+complete: dblp (275), openalex (26). Those entries report api_error, not not_found \
+-- a source that never answered is not evidence that a reference is absent.
+WARNING: Hosts that could not be reached (DNS / connection / TLS / timeout / 5xx): \
+dblp.org (275)
+ERROR: Source outage: 25.5% of entries could not be checked against a complete set \
+of sources (threshold 10%). Treat this run as incomplete and discard its \
+could-not-verify verdicts; exiting 5.
+"""
+
+
+class TestSourceConditionParsing:
+    def test_reproduces_the_real_outage(self):
+        cond = parse_source_condition(REAL_OUTAGE_OUTPUT)
+        assert cond == {
+            "entries_with_incomplete_lookups": 285,
+            "entries_total": 1119,
+            "incomplete_fraction": pytest.approx(0.255),
+            "per_source_failures": {"dblp": 275, "openalex": 26},
+        }
+
+    def test_a_healthy_run_reports_no_condition(self):
+        assert parse_source_condition("INFO: Loaded 1119 entries\nINFO: done") is None
+
+    def test_the_final_summary_wins(self):
+        """bibtex-check may report progressively; the last line is the total."""
+        progressive = (
+            "WARNING: 10 of 100 entries (10.0%) had at least one source lookup "
+            "that did not complete: dblp (10)\n"
+            "WARNING: 40 of 100 entries (40.0%) had at least one source lookup "
+            "that did not complete: dblp (35), openalex (5)\n"
+        )
+        cond = parse_source_condition(progressive)
+        assert cond is not None
+        assert cond["entries_with_incomplete_lookups"] == 40
+        assert cond["per_source_failures"] == {"dblp": 35, "openalex": 5}
+
+    def test_malformed_counts_do_not_raise(self):
+        """Provenance parsing must never break an evaluation."""
+        cond = parse_source_condition(
+            "WARNING: 5 of 50 entries (10.0%) had at least one source lookup "
+            "that did not complete: dblp (not-a-number), openalex (3)"
+        )
+        assert cond is not None
+        assert cond["per_source_failures"] == {"openalex": 3}
+
+
+def test_the_exit_code_is_the_one_the_tool_documents():
+    """Pinned because the whole guard keys on it."""
+    assert EXIT_SOURCE_OUTAGE == 5


### PR DESCRIPTION
`bibtex-check` exits 5 when failed lookups touch at least 10% of entries, printing *"Treat this run as incomplete and discard its could-not-verify verdicts."* The wrapper logged that at ERROR and then parsed the output and returned predictions anyway.

## It happened today

`dblp.org` went unreachable — every request timing out at 25s, homepage included, verified by direct curl and unrelated to our rate. The pre-screening ablation's first arm produced:

| | |
|---|---|
| DR | 0.8185 |
| FPR | 0.0312 |
| **coverage** | **1.0000** |
| entries with an incomplete lookup | **285 of 1,119 (25.5%)** |

Nothing downstream could tell those abstentions from real ones, and the file recorded full coverage. The arm has been discarded and the ablation stopped until DBLP returns.

## Fourth instance of one defect

A tool reports a problem honestly and the consumer discards the report. The others found today: API failures written into prediction files as per-entry verdicts, a timed-out batch scoring zero detections, and a freshness guard printing 46 stale files into a CI log that passed.

## The fix

`SourceOutageError` on exit 5, naming the fraction and per-source counts. `HALLMARK_ALLOW_SOURCE_OUTAGE=1` scores it anyway with a loud warning — deliberately awkward, because there are legitimate reasons to want such a run and none of them survive being silent about it.

`parse_source_condition` extracts the tool's own availability report so it can sit beside the numbers. Availability moves outcomes — a peer measured a factor of two in flag-clearance from one source going dark — so it is an experimental condition, not a diagnostic. Tests fixture on the actual output from today's outage, including the progressive-reporting and malformed-count cases.

## Also

`tool_version` was still `None`. The field and the version probe both landed earlier today and nothing connected them, so the first ablation run after adding them still wrote `tool_version: null` — for the very tool whose PATH-resolved build motivated the field. Now reads `bibtex-updater 1.10.1` from the pinned binary, verified end to end.

Suite: 1,286 passing, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp