### PR TITLE
Report the taxonomy conflation in the README, without relabelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,61 @@ See [`examples/03_custom_baseline.py`](examples/03_custom_baseline.py) for a com
 | `plausible_fabrication` | Entirely fabricated but realistic | Realistic author + plausible title |
 | `arxiv_version_mismatch` | Mixed preprint/published metadata | arXiv ID with conference venue claim |
 
+### Four of these modes describe papers that exist
+
+`wrong_venue`, `preprint_as_published`, `partial_author_list` and
+`arxiv_version_mismatch` are conditions on real works. An entry carrying one of
+them cites a paper that exists and says something inaccurate about it, usually a
+stale venue string or a preprint cited by its conference version. They sit under
+a label the agentic system prompt defines as "a HALLUCINATED (fabricated)
+citation", so a tool that correctly identifies a stale venue is scored as having
+found a fabrication. They are 26.1% of the positive class on `dev_public` and
+26.8% on `test_public`.
+
+**The ranking is not stable if they stop counting as fabrication.** Scoring every
+tool three ways — as shipped, with the four modes out of the scored set, and with
+them as negatives so flagging one is a false accusation:
+
+| split | folded out of the scored set | scored as false positives |
+|---|---|---|
+| `test_public` | Kendall tau 0.886, 14 of 21 tools change rank | tau 0.829, 17 of 21 change |
+| `dev_public` | tau 0.905, 15 of 20 change | tau 0.811, 17 of 20 change |
+
+The top of the table changes identity: `cascade_db_diagnosis` leads as shipped at
+MCC 0.897 on `test_public`, and `bibtexupdater` takes first place under
+as-false-positives on both splits (0.685 against 0.631).
+
+How much of a tool's credit comes from these modes varies widely, and no
+published column shows it. On `test_public` they are 27.0% of the cascade's 514
+detections, 23.2% of Sonnet 4.6's, 20.0% of `bibtexupdater`'s and 9.1% of
+`doi_only`'s. Detection rate on the four ranges from 0.065 (`doi_only`) to 1.000
+(the cascade), median 0.755 across 21 tools.
+
+Two controls bound what this means. Folding `hybrid_fabrication` alone moves
+nothing — tau 1.000 with no tool changing position on either public split — so
+the instability belongs to the four modes rather than to folding a mode class,
+though at 4.3% and 5.6% of positives that null carries less weight than the
+effect it contrasts with. And the cascade's 1.000 is not an artefact of how the
+entries were generated: a gradient-boosted classifier over surface features
+alone, with no lookup of any kind, reaches detection rate 0.468 on `dev_public`
+and 0.388 on `test_public` against false-positive rates of 0.045 and 0.096. Some
+separability is there, and it is far short of what the cascade achieves.
+
+`stress_test` inherits the same property by construction. It holds three modes,
+two of which are on this list: 75 of its 121 scored entries, 62%. It carries no
+VALID entries, so its false-positive rate is undefined and its MCC is 0.0 by
+degeneracy rather than by measurement, and every one of the cascade's misses
+there is on the two real-paper modes — folding them takes it from 0.953 to 1.000.
+
+**No labels change in this release.** Separating the two questions means
+relabelling across every split and moving every per-type and per-tier number, so
+the instability is reported rather than repaired; treat a ranking on the current
+target as a ranking over both questions at once. Reproduce with
+`python scripts/ablate_taxonomy_fold.py --split test_public`, which writes
+`tables/taxonomy_fold_ablation_*.csv` and rebuilds each tool's confusion matrix
+from `per_type_metrics`, validating it against that result's own published
+figures first. Discussion is in [issue #36](https://github.com/rpatrik96/hallmark/issues/36).
+
 ## Hosting & Croissant
 
 The dataset is mirrored on HuggingFace (parquet + jsonl + baseline results + RAI Croissant metadata):


### PR DESCRIPTION
The decision on #36 is to report the finding and defer the relabel, so this states it where a reader meets the taxonomy rather than leaving it in a PR body. **No labels, results or tables change.** One file, one section.

The section says that `wrong_venue`, `preprint_as_published`, `partial_author_list` and `arxiv_version_mismatch` are conditions on works that exist, that they are 26.1% and 26.8% of the positive class, and that the ranking is not stable if they stop counting as fabrication — 14 of 21 tools change rank on `test_public` when they leave the scored set, 17 of 21 when they become negatives, and the leader changes identity.

It adds the per-tool detection share, which is the part no published column carries: 27.0% of the cascade's 514 detections come from these four modes, against 23.2% for Sonnet 4.6, 20.0% for `bibtexupdater` and 9.1% for `doi_only`. That spread is why the ranking moves, and a reader currently has no way to see it.

Both controls are stated with the claim rather than left behind in #44. Folding `hybrid_fabrication` alone moves nothing, so the instability is specific to these four modes, and the null is qualified by its smaller population. Surface-only classification reaches DR 0.468 on `dev_public` and 0.388 on `test_public` against the cascade's 1.000, so that number is detection rather than the generator showing through — stated with the fact that some separability does exist.

One correction carried in: `stress_test` is 62% real-paper modes over its **121 scored entries**, not 61.5% over 122. The file's 122nd line is `__canary__stress_test`, which the loader drops, so dividing by 122 divides by a population that is never scored.

Every figure is reproducible from `scripts/ablate_taxonomy_fold.py` and `scripts/shortcut_control_four_modes.py`, both on `main`, and the section names the command.