### PR TITLE
fix(bibtexupdater): report an abstention as an abstention

### DIFF
--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -114,6 +114,44 @@ STATUS_TO_LABEL: dict[str, str] = {
     "skipped": "VALID",  # Conservative
 }
 
+#: Statuses whose ``VALID`` above is an **abstention**, not a verdict.
+#:
+#: ``STATUS_TO_LABEL`` collapses two different things onto ``VALID``: entries the
+#: tool checked and cleared (``verified``, ``url_verified``, ...) and entries it
+#: declined to judge because no source answered. Scoring the second group as a
+#: committed VALID is the documented conservative convention, but recording it as
+#: one is a reporting bug: ``EvaluationResult.num_uncertain`` came out 0 and
+#: ``coverage`` 1.0 on a run with 147 ``unconfirmed`` records, so the released
+#: JSON reported full coverage for a tool that answered 87% of the split.
+#:
+#: ``not_found`` is deliberately absent. bibtex-check sets ``abstained: true`` on
+#: it, but that flag means "could not affirmatively verify against a source",
+#: which for ``not_found`` coincides with the detection: of the 52 such records on
+#: ``dev_public``, 51 sit on HALLUCINATED entries. They are verdicts, and the
+#: mapping to HALLUCINATED is right. The same applies to ``partial_match``.
+ABSTENTION_STATUSES: frozenset[str] = frozenset(
+    {
+        "unconfirmed",
+        "api_error",
+        "network_error",
+        "coverage_incomplete",
+        "skipped",
+        "strict_warn_preprint_year",
+        "strict_warn_cnv",
+    }
+)
+
+#: Set to ``1`` to restore the pre-fix mapping, where an abstention is written as
+#: a committed VALID. Reproduces the published ``bibtex-updater`` rows exactly;
+#: it does not make them right.
+ABSTENTION_AS_VALID_ENV = "HALLMARK_BTU_ABSTENTION_AS_VALID"
+
+
+def abstentions_are_committed_valid() -> bool:
+    """True when the legacy mapping is requested via the environment."""
+    return os.environ.get(ABSTENTION_AS_VALID_ENV) == "1"
+
+
 # Map bibtex-check status to confidence
 STATUS_TO_CONFIDENCE: dict[str, float] = {
     "verified": 0.95,
@@ -900,6 +938,16 @@ def _parse_jsonl_output(
             if incomplete_not_found:
                 label = "VALID"
 
+            # An abstention is not a verdict. Emitting it as UNCERTAIN is what
+            # makes ``coverage`` and ``num_uncertain`` describe the run; under
+            # the conservative protocol these entries leave the confusion matrix
+            # rather than counting as committed VALID, so the DR/FPR/F1 triple
+            # becomes the selective one. Set HALLMARK_BTU_ABSTENTION_AS_VALID=1
+            # to reproduce a published row under the old convention.
+            is_abstention = status in ABSTENTION_STATUSES or incomplete_not_found
+            if is_abstention and not abstentions_are_committed_valid():
+                label = "UNCERTAIN"
+
             p_valid = record.get("p_valid")
             if incomplete_not_found:
                 confidence = 0.45
@@ -926,6 +974,11 @@ def _parse_jsonl_output(
                     confidence = raw_confidence
 
             reason_parts = [f"Status: {status}"]
+            if is_abstention:
+                reason_parts.append(
+                    "Abstention: no source answered, so this is not a verdict"
+                    + ("" if label == "UNCERTAIN" else " (scored as committed VALID)")
+                )
             if incomplete_not_found:
                 reason_parts.append(
                     "Lookup incomplete due to source errors/throttling — "

--- a/tests/test_abstention_is_not_a_verdict.py
+++ b/tests/test_abstention_is_not_a_verdict.py
@@ -1,0 +1,173 @@
+"""An abstention must not be written as a committed verdict.
+
+``STATUS_TO_LABEL`` collapses two different things onto ``VALID``: entries
+bibtex-check checked and cleared, and entries it declined to judge because no
+source answered. Scoring the second group conservatively as VALID is the
+documented convention; *recording* it as a committed verdict is a reporting bug.
+
+On ``dev_public`` the released aggregate reported ``num_uncertain: 0`` and
+``coverage: 1.0`` for a run whose raw output carries 147 ``unconfirmed``
+records — the tool answered 87% of the split and the JSON claimed 100%. The
+paper's Coverage column says 0.82, so the two artifacts disagreed and only the
+one nobody could recompute was wrong.
+
+What is deliberately *not* an abstention here: ``not_found`` and
+``partial_match``. bibtex-check sets ``abstained: true`` on ``not_found``, but
+that flag means "could not affirmatively verify against a source", which for
+this status coincides with the detection — of the 52 such records on
+``dev_public``, 51 sit on HALLUCINATED entries. Treating them as abstentions
+would surrender 51 correct detections and inflate the abstention count to the
+199 that produces the paper's 0.82.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hallmark.baselines.bibtexupdater import (
+    ABSTENTION_AS_VALID_ENV,
+    ABSTENTION_STATUSES,
+    STATUS_TO_LABEL,
+    _parse_jsonl_output,
+)
+
+
+def _write(tmp_path: Path, records: list[dict]) -> Path:
+    path = tmp_path / "btu_raw.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+    return path
+
+
+def _labels(tmp_path: Path, records: list[dict]) -> dict[str, str]:
+    preds = _parse_jsonl_output(_write(tmp_path, records), 10.0, len(records))
+    return {p.bibtex_key: p.label for p in preds}
+
+
+def test_every_abstention_status_maps_to_valid_in_the_legacy_table():
+    """The set is a re-reading of ``STATUS_TO_LABEL``, not a new policy.
+
+    If a status in this set ever stops mapping to VALID the two have diverged
+    and one of them is wrong.
+    """
+    for status in ABSTENTION_STATUSES:
+        assert STATUS_TO_LABEL.get(status) == "VALID", (
+            f"{status!r} is registered as an abstention but STATUS_TO_LABEL maps it to "
+            f"{STATUS_TO_LABEL.get(status)!r}. An abstention is a VALID that carries no "
+            "evidence; a status mapping elsewhere is a verdict and does not belong here."
+        )
+
+
+def test_unconfirmed_is_uncertain_not_committed_valid(tmp_path):
+    """The 147-record case that made coverage read 1.0."""
+    labels = _labels(
+        tmp_path,
+        [
+            {"key": "a", "status": "unconfirmed", "abstained": True, "p_valid": 0.22},
+            {"key": "b", "status": "verified", "abstained": False, "p_valid": 0.95},
+        ],
+    )
+    assert labels["a"] == "UNCERTAIN"
+    assert labels["b"] == "VALID", "a checked-and-cleared entry is still a committed VALID"
+
+
+def test_not_found_stays_a_detection_despite_its_abstained_flag(tmp_path):
+    """The 51-of-52 case: bibtex-check's ``abstained`` flag is not our signal."""
+    labels = _labels(
+        tmp_path,
+        [{"key": "a", "status": "not_found", "abstained": True, "p_valid": 0.05}],
+    )
+    assert labels["a"] == "HALLUCINATED", (
+        "not_found carries abstained=True but is a verdict: 51 of the 52 such records "
+        "on dev_public sit on HALLUCINATED entries. Reading the flag directly would "
+        "surrender them."
+    )
+
+
+def test_partial_match_stays_a_detection(tmp_path):
+    """The 85 records that separate the 0.82 accounting from the 0.746 one."""
+    labels = _labels(
+        tmp_path,
+        [{"key": "a", "status": "partial_match", "abstained": False, "p_valid": 0.30}],
+    )
+    assert labels["a"] == "HALLUCINATED"
+
+
+def test_source_outage_abstention_is_uncertain(tmp_path):
+    """``not_found`` reached while sources were throttled is not evidence."""
+    labels = _labels(
+        tmp_path,
+        [
+            {
+                "key": "a",
+                "status": "not_found",
+                "coverage_incomplete": True,
+                "p_valid": 0.45,
+            }
+        ],
+    )
+    assert labels["a"] == "UNCERTAIN", (
+        "a lookup that never completed cannot be a detection; it was already "
+        "downgraded to VALID, which recorded it as a committed verdict"
+    )
+
+
+def test_legacy_env_reproduces_the_published_mapping(tmp_path, monkeypatch):
+    """The escape hatch exists to reproduce a published row, not to bless it."""
+    records = [
+        {"key": "a", "status": "unconfirmed", "abstained": True, "p_valid": 0.22},
+        {"key": "b", "status": "not_found", "coverage_incomplete": True},
+    ]
+    monkeypatch.setenv(ABSTENTION_AS_VALID_ENV, "1")
+    assert set(_labels(tmp_path, records).values()) == {"VALID"}
+    monkeypatch.delenv(ABSTENTION_AS_VALID_ENV)
+    assert set(_labels(tmp_path, records).values()) == {"UNCERTAIN"}
+
+
+def test_coverage_now_describes_the_run(tmp_path):
+    """End to end: the reported coverage matches the answered fraction.
+
+    This is the assertion the released JSON failed. Ten entries, three of them
+    abstentions, must not report coverage 1.0.
+    """
+    from hallmark.dataset.schema import BenchmarkEntry
+    from hallmark.evaluation.metrics import evaluate
+
+    records = (
+        [{"key": f"h{i}", "status": "not_found", "p_valid": 0.05} for i in range(4)]
+        + [{"key": f"v{i}", "status": "verified", "p_valid": 0.95} for i in range(3)]
+        + [
+            {"key": f"u{i}", "status": "unconfirmed", "abstained": True, "p_valid": 0.22}
+            for i in range(3)
+        ]
+    )
+    preds = _parse_jsonl_output(_write(tmp_path, records), 10.0, len(records))
+
+    entries = [
+        BenchmarkEntry(
+            bibtex_key=r["key"],
+            bibtex_type="article",
+            fields={"title": "t", "author": "a", "year": "2020"},
+            label="HALLUCINATED" if r["key"].startswith(("h", "u")) else "VALID",
+            hallucination_type="plausible_fabrication" if r["key"].startswith(("h", "u")) else None,
+            difficulty_tier=3 if r["key"].startswith(("h", "u")) else None,
+            source="test",
+        )
+        for r in records
+    ]
+
+    result = evaluate(entries, preds, tool_name="bibtexupdater")
+    assert result.num_uncertain == 3, "the three abstentions must be counted as such"
+    assert result.coverage == pytest.approx(0.7), (
+        f"coverage {result.coverage} — the tool answered 7 of 10 entries; reporting 1.0 "
+        "is the defect this test exists for"
+    )
+
+
+def test_the_guard_is_not_vacuous():
+    """``ABSTENTION_STATUSES`` must actually name the status that caused this."""
+    assert "unconfirmed" in ABSTENTION_STATUSES
+    assert "not_found" not in ABSTENTION_STATUSES
+    assert "partial_match" not in ABSTENTION_STATUSES

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -165,7 +165,11 @@ class TestParseJsonlOutput:
             }
         ]
         (pred,) = _parse(tmp_path, records)
-        assert pred.label == "VALID"
+        # UNCERTAIN, not VALID: the lookup never completed, so the entry is
+        # unanswered rather than cleared. Writing it as a committed VALID is
+        # what made ``coverage`` read 1.0 on runs full of abstentions
+        # (tests/test_abstention_is_not_a_verdict.py).
+        assert pred.label == "UNCERTAIN"
         assert pred.confidence == pytest.approx(0.45)
         # Reason explains the abstention while keeping the leading raw-status
         # segment that run_bibtex_check_with_status parses for the cascade.
@@ -191,8 +195,8 @@ class TestParseJsonlOutput:
         assert pred.confidence == pytest.approx(0.65)  # 1 - p_valid
 
     def test_coverage_incomplete_informational_for_other_statuses(self, tmp_path: Path) -> None:
-        """coverage_incomplete only rewrites not_found; api_error keeps its
-        conservative-VALID mapping with p_valid-derived confidence."""
+        """coverage_incomplete only rewrites not_found; api_error is already an
+        abstention by status and keeps its p_valid-derived confidence."""
         records: list[dict[str, Any]] = [
             {
                 "key": "e",
@@ -206,9 +210,11 @@ class TestParseJsonlOutput:
             }
         ]
         (pred,) = _parse(tmp_path, records)
-        assert pred.label == "VALID"
+        # ``coverage_incomplete`` still rewrites nothing here -- api_error is an
+        # abstention on its own account, by status, and is reported as one.
+        assert pred.label == "UNCERTAIN"
         assert pred.confidence == pytest.approx(0.5)
-        assert "abstention" not in pred.reason
+        assert "throttling" not in pred.reason
 
 
 class TestTransportStatusMapping:
@@ -235,7 +241,9 @@ class TestTransportStatusMapping:
             }
         ]
         (pred,) = _parse(tmp_path, records)
-        assert pred.label == "VALID"
+        # The point of this test is that a transport failure is never evidence
+        # of fabrication. UNCERTAIN says that more precisely than VALID did.
+        assert pred.label == "UNCERTAIN"
         assert pred.label != "HALLUCINATED"
 
     def test_unknown_future_status_never_parses_to_hallucinated(self, tmp_path: Path) -> None:


### PR DESCRIPTION
`bibtexupdater_dev_public.json` reports `num_uncertain: 0` and `coverage: 1.0` for a run whose raw output carries **147 `unconfirmed` records**. The paper's Coverage column says `0.82`. The two artifacts disagreed, and the wrong one was the one a reader can recompute.

Cause: `STATUS_TO_LABEL` collapses two different things onto `VALID` — entries bibtex-check checked and cleared, and entries it declined to judge because no source answered. Scoring the second group conservatively as VALID is the documented convention; *recording* it as a committed verdict is a reporting bug.

## What changed

- `ABSTENTION_STATUSES` names the seven statuses whose `VALID` is an abstention rather than a verdict (`unconfirmed`, `api_error`, `network_error`, `coverage_incomplete`, `skipped`, `strict_warn_preprint_year`, `strict_warn_cnv`). They parse to `UNCERTAIN`.
- `HALLMARK_BTU_ABSTENTION_AS_VALID=1` restores the old mapping, to reproduce a published row.
- A `not_found` reached while sources were throttled (`coverage_incomplete`) is an abstention too — it was already downgraded to VALID, which recorded it as a committed verdict.

## What deliberately did *not* change

`not_found` and `partial_match` stay detections. bibtex-check sets `abstained: true` on `not_found`, but that flag means "could not affirmatively verify against a source", which for this status **coincides with the detection**: of the 52 such records on `dev_public`, **51 sit on HALLUCINATED entries**. Reading the flag directly would surrender them.

That matters because it explains a three-way disagreement nobody had noticed:

| accounting | abstentions on `dev_public` | coverage | what it counts |
|---|---|---|---|
| released JSON | 0 | 1.00 | nothing — the bug |
| paper `tab:results` | 199 | 0.82 | `unconfirmed` + 52 `not_found`, 51 of which are correct detections |
| `coverage_reporting.md` | 284 | 0.746 | the above + 85 `partial_match`, also scored as detections |
| **this PR** | **147** | **0.862** | only entries the tool did not commit on |

Both published figures count entries the tool committed on. **Which one the paper reports is your call** — it is annotated in hallmark-paper#11, not decided here.

## Impact, measured

Re-scoring `results/relabel_delta/btu_v1_2_0/dev_public/btu_raw.jsonl` through the fixed parser: `coverage` 0.862, `num_uncertain` 147, and the conservative triple becomes **DR 0.984 / FPR 0.056 / F1 0.967** — the abstentions leave the confusion matrix instead of counting as committed VALID. **No released result is regenerated by this commit.**

## Tests

`tests/test_abstention_is_not_a_verdict.py`, 8 cases. Reverting the fix fails 4 of them, so the guard is not vacuous. Three existing tests in `test_bibtexupdater.py` asserted the defect (a transport failure parsing to `VALID`); their intent — a failed lookup is never evidence of fabrication — is unchanged, and `UNCERTAIN` states it more precisely, so they now assert that.

Full suite: 1,399 passed, 5 skipped. ruff clean. mypy has one pre-existing error in `contribution/validate_entry.py`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp