### PR TITLE
The baselines workflow reported success with every job failed

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -19,6 +19,12 @@ jobs:
     name: Evaluate ${{ matrix.baseline }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Kept so one throttled baseline does not abort the others -- these hit
+    # Semantic Scholar and CrossRef from a shared runner IP and a 429 is
+    # routine. The cost is that the workflow's own conclusion stops meaning
+    # anything: on 2026-08-31 run 33390676403 reported SUCCESS with all four
+    # jobs failed, and nobody looked for months. The `gate` job at the bottom
+    # restores the signal without giving up the isolation.
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -147,3 +153,37 @@ jobs:
           name: combined-results
           path: results/
           if-no-files-found: warn
+
+  gate:
+    name: Fail if any baseline failed
+    runs-on: ubuntu-latest
+    needs: [baseline, aggregate]
+    if: always()
+    steps:
+      # `continue-on-error` on the matrix means `needs.baseline.result` is
+      # 'success' even when every job inside it failed; the honest signal is
+      # `outcome`, which the matrix does not expose to a dependent job. So read
+      # the run's own jobs through the API and fail on any conclusion that is
+      # not success or skipped. This is the check that would have caught the
+      # four TypeError failures on 2026-08-31 the same morning.
+      - name: Check every job in this run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '.jobs[] | select(.name != "Fail if any baseline failed") |
+                  [.name, .conclusion] | @tsv' > jobs.tsv
+          cat jobs.tsv
+          if ! [ -s jobs.tsv ]; then
+            echo "::error::no jobs reported for this run -- refusing to pass blind"
+            exit 1
+          fi
+          failed=$(awk -F'\t' '$2 != "success" && $2 != "skipped"' jobs.tsv || true)
+          if [ -n "$failed" ]; then
+            echo "::error::baseline jobs failed:"
+            echo "$failed"
+            exit 1
+          fi
+          echo "all jobs succeeded"

--- a/scripts/check_source_reachability.py
+++ b/scripts/check_source_reachability.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Refuse to start a long run against a source that is not answering.
+
+The ``bibtex-updater`` pre-screening ablation was discarded three times in one
+day. Twice the cause was a source outage the run could only discover at the end:
+``bibtex-check`` exits 5 and HALLMARK's wrapper raises ``SourceOutageError``,
+which is correct -- a source that never answered is not evidence a reference is
+absent -- but by then 90 minutes are gone. The last attempt (2026-09-04, 20:49)
+reported 244 of 1,119 entries with an incomplete lookup, 230 of them DBLP.
+
+This is the cheap version of that check, run *before* the work: one request per
+source, and a non-zero exit if a required one does not answer. Two minutes of
+probing against ninety of scoring.
+
+    python scripts/check_source_reachability.py                    # report only
+    python scripts/check_source_reachability.py --require dblp,openalex
+
+Exit codes
+----------
+0   every required source answered
+1   at least one required source did not
+2   nothing was probed (bad --require, or httpx missing) -- never a pass
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+#: One cheap, cacheable, well-formed query per source. Each asks for a real
+#: record rather than hitting a bare root, because several of these return 200
+#: from a CDN at the root while the query path behind it is down -- the same
+#: shape as the HTTP-202 defect in the DOI check, where the status answered a
+#: question nobody asked.
+PROBES: dict[str, str] = {
+    "dblp": "https://dblp.org/search/publ/api?q=attention+is+all+you+need&format=json&h=1",
+    "openalex": "https://api.openalex.org/works?filter=doi:10.48550/arxiv.1706.03762&per-page=1",
+    "crossref": "https://api.crossref.org/works/10.1145/3292500.3330701",
+    "semanticscholar": "https://api.semanticscholar.org/graph/v1/paper/arXiv:1706.03762?fields=title",
+    "arxiv": "http://export.arxiv.org/api/query?id_list=1706.03762&max_results=1",
+    "datacite": "https://api.datacite.org/dois/10.48550/arxiv.1706.03762",
+}
+
+
+@dataclass
+class Result:
+    source: str
+    ok: bool
+    status: int | None
+    elapsed: float
+    detail: str
+
+
+def probe(source: str, url: str, timeout: float, mailto: str | None) -> Result:
+    """One request, one retry. A 429 counts as reachable but throttled."""
+    import httpx
+
+    headers = {"User-Agent": f"hallmark-source-check (mailto:{mailto})"} if mailto else {}
+    last = ""
+    for attempt in (1, 2):
+        started = time.monotonic()
+        try:
+            response = httpx.get(url, timeout=timeout, headers=headers, follow_redirects=True)
+        except Exception as exc:  # any transport failure is the finding
+            last = f"{type(exc).__name__}: {exc}"
+            elapsed = time.monotonic() - started
+            if attempt == 2:
+                return Result(source, False, None, elapsed, last)
+            time.sleep(1.0)
+            continue
+        elapsed = time.monotonic() - started
+        if response.status_code == 429:
+            # Throttled is not down: the service answered and asked us to slow
+            # down, which pacing handles. Reported, not failed.
+            return Result(source, True, 429, elapsed, "throttled (429) -- reachable, pace the run")
+        if response.status_code < 400:
+            return Result(source, True, response.status_code, elapsed, "ok")
+        last = f"HTTP {response.status_code}"
+        if attempt == 2:
+            return Result(source, False, response.status_code, elapsed, last)
+        time.sleep(1.0)
+    return Result(source, False, None, 0.0, last or "no attempt completed")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--require",
+        default="",
+        help="comma-separated sources that must answer (default: report only, always exit 0)",
+    )
+    ap.add_argument("--timeout", type=float, default=15.0)
+    ap.add_argument("--mailto", default=None, help="contact address for the polite pool")
+    args = ap.parse_args()
+
+    try:
+        import httpx  # noqa: F401
+    except ImportError:
+        print("httpx is not installed -- cannot probe, refusing to report a pass", file=sys.stderr)
+        return 2
+
+    required = [s.strip() for s in args.require.split(",") if s.strip()]
+    unknown = [s for s in required if s not in PROBES]
+    if unknown:
+        print(
+            f"unknown source(s): {', '.join(unknown)}; known: {', '.join(PROBES)}", file=sys.stderr
+        )
+        return 2
+
+    results = [probe(name, url, args.timeout, args.mailto) for name, url in PROBES.items()]
+    width = max(len(r.source) for r in results)
+    for r in results:
+        mark = "ok  " if r.ok else "DOWN"
+        req = " (required)" if r.source in required else ""
+        print(f"  {mark}  {r.source:<{width}}  {r.elapsed:5.2f}s  {r.detail}{req}")
+
+    if not required:
+        print("\nreport only -- pass --require to gate a run on this")
+        return 0
+
+    down = [r.source for r in results if r.source in required and not r.ok]
+    if down:
+        print(
+            f"\nrequired source(s) not answering: {', '.join(down)}. "
+            "A run started now would score entries whose lookups never completed, "
+            "which is what the exit-5 guard discards at the end. Wait, or drop the "
+            "source from the condition and say so in the write-up.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nall required sources answered: {', '.join(required)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_reachability_precheck.py
+++ b/tests/test_source_reachability_precheck.py
@@ -1,0 +1,111 @@
+"""A source that is not answering must stop a run before it starts, not after.
+
+The prescreening ablation was discarded three times in one day. Twice the cause
+was a source outage the run could only discover at the end: ``bibtex-check``
+exits 5, the wrapper raises ``SourceOutageError``, and ninety minutes are gone.
+The last attempt reported 244 of 1,119 entries with an incomplete lookup, 230 of
+them DBLP.
+
+These tests pin the classification, because the interesting cases are the ones
+where a status code answers a question nobody asked -- the same shape as the
+HTTP-202 defect in the DOI check, where a publisher's bot mitigation was read as
+proof a reference did not exist.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_source_reachability import PROBES, main, probe
+
+
+def _response(status: int) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    return r
+
+
+def test_throttled_is_reachable_not_down():
+    """429 means the service answered and asked us to slow down.
+
+    Calling it an outage would block every run against a busy source; pacing is
+    the fix, and the ablation got *faster* once it was paced (2.4 s/entry
+    against 5.7).
+    """
+    with patch("httpx.get", return_value=_response(429)) as get:
+        result = probe("openalex", PROBES["openalex"], 5.0, None)
+    assert result.ok is True
+    assert result.status == 429
+    assert "throttled" in result.detail
+    assert get.call_count == 1, "a 429 is an answer; retrying it wastes the budget"
+
+
+def test_server_error_is_down_after_a_retry():
+    """The live DBLP failure mode: HTTP 500, twice."""
+    with patch("httpx.get", return_value=_response(500)) as get:
+        result = probe("dblp", PROBES["dblp"], 5.0, None)
+    assert result.ok is False
+    assert get.call_count == 2, "one flake must not fail the gate; a persistent fault must"
+
+
+def test_a_single_flake_does_not_fail_the_gate():
+    with patch("httpx.get", side_effect=[_response(500), _response(200)]):
+        result = probe("dblp", PROBES["dblp"], 5.0, None)
+    assert result.ok is True
+
+
+def test_transport_failure_is_down():
+    import httpx
+
+    with patch("httpx.get", side_effect=httpx.ConnectError("no route")):
+        result = probe("dblp", PROBES["dblp"], 5.0, None)
+    assert result.ok is False
+    assert result.status is None
+    assert "ConnectError" in result.detail
+
+
+def test_required_source_down_exits_nonzero(capsys):
+    """The whole point: a run gated on this must not start."""
+    with patch("httpx.get", return_value=_response(500)):
+        code = main_with_args(["--require", "dblp", "--timeout", "0.1"])
+    assert code == 1
+    assert "dblp" in capsys.readouterr().err
+
+
+def test_all_required_up_exits_zero():
+    with patch("httpx.get", return_value=_response(200)):
+        assert main_with_args(["--require", "dblp,openalex", "--timeout", "0.1"]) == 0
+
+
+def test_unknown_source_never_reports_a_pass(capsys):
+    """A typo in --require must not read as 'nothing was down'."""
+    assert main_with_args(["--require", "dblpp"]) == 2
+    assert "unknown source" in capsys.readouterr().err
+
+
+def test_report_only_mode_never_fails():
+    with patch("httpx.get", return_value=_response(500)):
+        assert main_with_args(["--timeout", "0.1"]) == 0
+
+
+def main_with_args(argv: list[str]) -> int:
+    with (
+        patch.object(sys, "argv", ["check_source_reachability.py", *argv]),
+        patch("time.sleep"),
+    ):
+        return main()
+
+
+def test_every_probe_asks_for_a_real_record():
+    """Not a bare root.
+
+    Several of these serve 200 from a CDN at the root while the query path
+    behind it is down, which is exactly the status-answering-the-wrong-question
+    failure this script exists to avoid.
+    """
+    for source, url in PROBES.items():
+        assert "?" in url or url.count("/") > 3, f"{source} probes a bare root: {url}"


### PR DESCRIPTION
Run [33390676403](https://github.com/rpatrik96/hallmark/actions/runs/33390676403) (2026-08-31, scheduled) reported **success** with all four of its jobs failed:

| Job | Conclusion |
|---|---|
| Evaluate doi_only | failure |
| Evaluate verify_citations | failure |
| Evaluate bibtexupdater | failure |
| Evaluate harc | failure |
| Aggregate Results | success |

`continue-on-error: true` on the matrix plus `if: always()` on the aggregate is the mask. Two distinct causes were sitting in those logs — `run_verify_citations()` raising `TypeError` on the `split` kwarg, so that baseline could not run at all, and `validate-results --strict` failing on a truncated HaRC file. Both are fixed on `main`; the mask was not.

## The gate

`continue-on-error` stays. These baselines hit Semantic Scholar and CrossRef from a shared runner IP and a 429 is routine, so one throttled baseline must not abort the others. What was missing is a final job that fails when anything inside the matrix did.

It cannot use `needs.baseline.result` — that reads `success` even when every job in the matrix failed, and `outcome` is not exposed to a dependent job. So the gate reads the run's own jobs through the API and fails on any conclusion that is neither `success` nor `skipped`. An empty job list fails too, rather than passing blind.

## The source precheck

`scripts/check_source_reachability.py`. The prescreening ablation was discarded three times in one day; twice the cause was a source outage the run could only discover at the end, when `bibtex-check` exits 5 and ninety minutes are gone. The last attempt (2026-09-04, 20:49) reported **244 of 1,119 entries with an incomplete lookup, 230 of them DBLP**.

Two classifications matter, and both are tested:

- **A 429 is reachable, not down.** The service answered and asked us to slow down. Pacing made the ablation *faster* — 2.4 s/entry against 5.7 — so treating throttling as an outage would block every run against a busy source.
- **Each probe asks for a real record, not a bare root.** Several of these serve 200 from a CDN at the root while the query path behind it is down. That is the same shape as the HTTP-202 defect in the DOI check, where a publisher's bot mitigation was read as proof a reference did not exist.

DBLP right now: one 200 at 3.97 s, then 500 twice. Intermittent — which is exactly what the single retry distinguishes from a flake.

```
python scripts/check_source_reachability.py --require dblp,openalex --mailto <addr>
```

Exit 0 all required answered, 1 one did not, 2 nothing was probed (a typo in `--require`, or `httpx` missing) — never a silent pass.

## Tests

`tests/test_source_reachability_precheck.py`, 9 cases. Neutering the 429 branch fails the throttling test, so the guard is not vacuous. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp