### PR TITLE
fix(site): point the companion site at the data directory that exists

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -127,7 +127,7 @@
       <h3 style="margin:34px 0 12px">Splits</h3>
       <div class="card-grid" id="split-cards"></div>
       <p class="note" style="margin-top:14px">Counts from the released
-        <code>data/v1.0/metadata.json</code> (corpus <span class="corpus-version">v1.2.0</span>, post ground-truth relabel). The
+        <code>data/v1.2/metadata.json</code> (corpus <span class="corpus-version">v1.2.0</span>, post ground-truth relabel). The
         held-out split stays private for contamination resistance; extension splits are
         evaluation-only.</p>
     </div>
@@ -139,7 +139,7 @@
       <p class="kicker">Explore the results</p>
       <h2 class="section-title">Verifier results, filterable</h2>
       <p class="section-lead">All numbers are recomputed from the released per-run metric files
-        in <code>data/v1.0/baseline_results/</code> and the released extension-split metrics.
+        in <code>data/v1.2/baseline_results/</code> and the released extension-split metrics.
         Verifiers may abstain (UNCERTAIN): the coverage column shows the share of entries each
         verifier commits to, and headline metrics follow the paper&rsquo;s scoring conventions.
         <a href="https://github.com/rpatrik96/bibtexupdater"><code>bibtex-updater</code></a>


### PR DESCRIPTION
`data/v1.0/` was renamed to `data/v1.2/` in tag `v1.2.3`. `site/index.html` lines 130 and 142 still named the old path — the "where the counts come from" note and the baseline-results pointer — so a reader following either got a 404 on the one page that tells them where to look.

Both targets verified present. Merging this triggers a Pages deploy, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp