### PR TITLE
The released bibtex-updater results claimed full coverage

### DIFF
--- a/data/v1.2/baseline_results/bibtexupdater_dev_public.json
+++ b/data/v1.2/baseline_results/bibtexupdater_dev_public.json
@@ -17,7 +17,7 @@
   "ece": 0.38290504286914884,
   "auroc": 0.6697595198116302,
   "auprc": 0.7713178460550552,
-  "num_uncertain": 0,
+  "num_uncertain": 147,
   "tier3_f1": 0.8302872062663185,
   "detection_rate_ci": null,
   "f1_hallucination_ci": null,
@@ -144,7 +144,7 @@
       "count": 47
     }
   },
-  "coverage": 1.0,
+  "coverage": 0.8624,
   "coverage_adjusted_f1": 0.8903993203058623,
   "type_accuracy": {
     "overall": NaN,
@@ -483,7 +483,8 @@
     "kind": "btu_standalone",
     "splits": [
       "dev_public"
-    ]
+    ],
+    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/dev_public/btu_raw.jsonl under ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports. See scripts/rescore_btu_from_raw.py."
   },
   "_btu_status_histogram": {
     "arxiv_id_mismatch": 18,

--- a/data/v1.2/baseline_results/bibtexupdater_test_public.json
+++ b/data/v1.2/baseline_results/bibtexupdater_test_public.json
@@ -17,7 +17,7 @@
   "ece": 0.3991794010533843,
   "auroc": 0.6741792648584556,
   "auprc": 0.8189893946307215,
-  "num_uncertain": 0,
+  "num_uncertain": 101,
   "tier3_f1": 0.8456790123456791,
   "detection_rate_ci": null,
   "f1_hallucination_ci": null,
@@ -144,7 +144,7 @@
       "count": 34
     }
   },
-  "coverage": 1.0,
+  "coverage": 0.8761,
   "coverage_adjusted_f1": 0.900990099009901,
   "type_accuracy": {
     "overall": NaN,
@@ -483,7 +483,8 @@
     "kind": "btu_standalone",
     "splits": [
       "test_public"
-    ]
+    ],
+    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/test_public/btu_raw.jsonl under ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports. See scripts/rescore_btu_from_raw.py."
   },
   "_btu_status_histogram": {
     "arxiv_id_mismatch": 14,

--- a/data/v1.2/baseline_results/manifest.json
+++ b/data/v1.2/baseline_results/manifest.json
@@ -2,14 +2,14 @@
   "version": "1.0",
   "files": {
     "bibtexupdater_dev_public.json": {
-      "sha256": "ffc80199709b72e5afb6e4b8d45476b3746ccde8f9825c43b59b7ab5191aed8b",
+      "sha256": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
       "baseline": "bibtexupdater",
       "split": "dev_public",
       "num_entries": 1119,
       "f1_hallucination": 0.8903993203058623
     },
     "bibtexupdater_test_public.json": {
-      "sha256": "6cd2f9acc540179a88f8b94875433ff313a9f33b3ecf97247b5e7209ff55b82f",
+      "sha256": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
       "baseline": "bibtexupdater",
       "split": "test_public",
       "num_entries": 831,

--- a/scripts/rescore_btu_from_raw.py
+++ b/scripts/rescore_btu_from_raw.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Correct ``coverage`` and ``num_uncertain`` on a released ``bibtex-updater`` result.
+
+The released aggregates report ``coverage: 1.0`` and ``num_uncertain: 0`` for runs
+whose raw output carries 147 (``dev_public``) and 101 (``test_public``)
+abstentions. The wrapper wrote every abstention as a committed VALID, so the
+field that was supposed to record them recorded nothing. The paper's Coverage
+column says otherwise, and the artifact a reader can recompute was the wrong one.
+
+**Only those two fields change.** The DR/FPR/F1 triple stays exactly as released,
+which is the paper's documented convention: abstentions score as committed-VALID
+in the triple, and Coverage reports the fraction the tool committed to. Two
+reasons not to re-score the triple here:
+
+1. It would not be comparable. Under the conservative protocol abstentions leave
+   the confusion matrix, so a re-scored ``bibtex-updater`` would be the one tool
+   in the cohort scored selectively while the other twenty are scored committed.
+   Re-scoring lifted its ``test_public`` MCC from 0.750 to 0.918 and made it the
+   leader under all three taxonomy-fold scorings -- an artifact of dropping the
+   101 entries it abstained on, not a result.
+2. It would not reproduce anyway. The released runs go through
+   ``run_with_prescreening``, whose overrides are not in the raw JSONL, so a
+   raw-only parse gives DR 0.820 / FPR 0.051 against the released 0.865 / 0.092.
+
+**The raw file must be the one behind the aggregate.**
+``data/v1.2/baseline_results/bibtexupdater_raw_dev_public.jsonl`` is *not* -- it
+is a 0.10.0-era run with no ``unconfirmed`` records at all -- so this checks the
+status histogram against the aggregate's own ``_btu_status_histogram`` and
+refuses to write when they disagree.
+
+    python scripts/rescore_btu_from_raw.py --split dev_public \
+        --raw results/relabel_delta/btu_v1_2_0/dev_public/btu_raw.jsonl --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def status_histogram(raw_path: Path) -> dict[str, int]:
+    counts: collections.Counter[str] = collections.Counter()
+    for line in raw_path.read_text().splitlines():
+        if line.strip():
+            counts[json.loads(line).get("status", "")] += 1
+    return dict(counts)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--split", required=True)
+    ap.add_argument("--raw", type=Path, required=True, help="raw bibtex-check JSONL")
+    ap.add_argument("--results-dir", type=Path, default=REPO_ROOT / "data/v1.2/baseline_results")
+    ap.add_argument("--data-dir", type=Path, default=REPO_ROOT / "data")
+    ap.add_argument("--version", default="v1.2")
+    ap.add_argument("--apply", action="store_true", help="write (default: dry run)")
+    args = ap.parse_args()
+
+    from hallmark.baselines.bibtexupdater import _parse_jsonl_output
+    from hallmark.dataset.loader import SPLIT_PATHS
+    from hallmark.dataset.schema import load_entries
+
+    target = args.results_dir / f"bibtexupdater_{args.split}.json"
+    if not target.is_file():
+        print(f"no released result at {target}", file=sys.stderr)
+        return 2
+    released = json.loads(target.read_text())
+
+    observed = status_histogram(args.raw)
+    recorded = released.get("_btu_status_histogram")
+    if recorded and observed != recorded:
+        print(
+            f"{args.raw} does not match the aggregate it would annotate.\n"
+            f"  raw file : {observed}\n"
+            f"  aggregate: {recorded}\n"
+            "Counting abstentions from a different run than the one published would "
+            "put a coverage figure on a result it does not describe.",
+            file=sys.stderr,
+        )
+        return 1
+
+    split_file = args.data_dir / args.version / SPLIT_PATHS[args.split]
+    entries = load_entries(split_file)
+    predictions = _parse_jsonl_output(args.raw, 0.0, len(entries))
+    abstentions = sum(1 for p in predictions if p.label == "UNCERTAIN")
+    answered = sum(1 for p in predictions if p.label != "UNCERTAIN")
+    coverage = answered / len(entries)
+
+    print(f"{args.split}: {len(entries)} entries, {len(predictions)} records")
+    print(f"  coverage        {released['coverage']}  ->  {coverage:.4f}")
+    print(f"  num_uncertain   {released['num_uncertain']}  ->  {abstentions}")
+    print("  DR/FPR/F1       unchanged (committed-VALID convention, as released)")
+
+    if not args.apply:
+        print("\nDRY RUN -- nothing written. Re-run with --apply.")
+        return 0
+
+    released["coverage"] = round(coverage, 4)
+    released["num_uncertain"] = abstentions
+    released.setdefault("_provenance", {})["coverage_corrected"] = (
+        f"coverage and num_uncertain recounted from {args.raw.as_posix()} under "
+        "ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores "
+        "abstentions as committed-VALID, which is the convention the paper reports. "
+        "See scripts/rescore_btu_from_raw.py."
+    )
+    target.write_text(json.dumps(released, indent=2, ensure_ascii=False) + "\n")
+    print(f"\nwrote {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tables/provenance.json
+++ b/tables/provenance.json
@@ -1,8 +1,34 @@
 {
+  "base_rate_precision.csv": {
+    "generator": "scripts/compute_base_rate_precision.py",
+    "inputs": {
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
+      "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
+      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
+      "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",
+      "data/v1.2/baseline_results/doi_only_test_public.json": "716ed587dc829f3b549ad5e846310a4705626758c80b432e42218d4aad274fda",
+      "data/v1.2/baseline_results/llm_agentic_btu_openai_test_public.json": "f8001545cd20f90ea06bd9a13590c74d5e32491a0a573c59fa249de2edc92f20",
+      "data/v1.2/baseline_results/llm_agentic_btu_sonnet_4_6_test_public.json": "0963a85c4f81f985824784389e3b8a890d3d6aabaa992070d42acdb115ad875c",
+      "data/v1.2/baseline_results/llm_agentic_openai_test_public.json": "72c88ccfbfb11e51a2e84307649b31da6d8ff9695871412b9cea7e4349bacc93",
+      "data/v1.2/baseline_results/llm_openai_gpt54_test_public.json": "083db8e3aee44cb76dd63a2b9fa6977c5f2a8cfdbcb267c02b4dc3e5415faba8",
+      "data/v1.2/baseline_results/llm_openai_test_public.json": "2f9d90370a88ea219f15f644a26cd1eecfbaeedf973c8bd2b75feeaecd0d38fa",
+      "data/v1.2/baseline_results/llm_openrouter_claude_opus_4_7_test_public.json": "76ac6ee463bc94091e93125333b8ff8f3ae98461d6ff7f31b7667be599ce0b45",
+      "data/v1.2/baseline_results/llm_openrouter_claude_sonnet_4_6_test_public.json": "e6c1f49975d71787d5dcefb213a0c9e7dcb50f6a350577f062d77f14a8a1f0ec",
+      "data/v1.2/baseline_results/llm_openrouter_deepseek_r1_test_public.json": "1be5ff175483727ffd35644f394b0fe556dc958acddf0e6a2af95ead9689ab6d",
+      "data/v1.2/baseline_results/llm_openrouter_deepseek_v3_test_public.json": "67f12ffeb2fcc28fe6b6fc2154ffadab6f71d89be8520a80f11c71822cf2378f",
+      "data/v1.2/baseline_results/llm_openrouter_gemini_flash_test_public.json": "92e214dddaf601a17da430d2dbe2d4e4f5fedaa6741f9cdcbadf55c09073ee75",
+      "data/v1.2/baseline_results/llm_openrouter_gemini_pro_test_public.json": "28f783bb26239d324305d51912eebf015fc5dbdb68a4bc591e2d5e1ec5d80515",
+      "data/v1.2/baseline_results/llm_openrouter_llama_4_maverick_test_public.json": "3747f84716fb0c78ccf573f0acee9db083f3823192b4d0a76460c2364bb85bf4",
+      "data/v1.2/baseline_results/llm_openrouter_mistral_test_public.json": "2f71622e7f10c85a8c150e70e722c4dbcf67279c6e2070151f5883221ebdf417",
+      "data/v1.2/baseline_results/llm_openrouter_qwen_max_test_public.json": "d056b6dec811bbd02114a993bd033fe023ce493f42ce3b60ced096d34c3917e2",
+      "data/v1.2/baseline_results/llm_openrouter_qwen_test_public.json": "8fbe6f79acba8de6618131ec2c3819ab7391e0eb8ecebf34ae3ef60c1f052f81",
+      "data/v1.2/baseline_results/llm_tool_augmented_test_public.json": "7d7733e0363906790592d11a953af83590024f0c54d7b56e290680dfa6a3e836"
+    }
+  },
   "taxonomy_fold_ablation_dev_public.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "ffc80199709b72e5afb6e4b8d45476b3746ccde8f9825c43b59b7ab5191aed8b",
+      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/cascade_db_diagnosis_dev_public.json": "5df803dde0d7fe80413072132677630b09761e9d313370611712ae0a7851747c",
       "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
@@ -27,7 +53,7 @@
   "taxonomy_fold_ablation_dev_public_hybrid_fabrication.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "ffc80199709b72e5afb6e4b8d45476b3746ccde8f9825c43b59b7ab5191aed8b",
+      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/cascade_db_diagnosis_dev_public.json": "5df803dde0d7fe80413072132677630b09761e9d313370611712ae0a7851747c",
       "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
@@ -60,7 +86,7 @@
   "taxonomy_fold_ablation_test_public.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "6cd2f9acc540179a88f8b94875433ff313a9f33b3ecf97247b5e7209ff55b82f",
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",
@@ -86,7 +112,7 @@
   "taxonomy_fold_ablation_test_public_hybrid_fabrication.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "6cd2f9acc540179a88f8b94875433ff313a9f33b3ecf97247b5e7209ff55b82f",
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",

--- a/tests/test_released_results_record_their_abstentions.py
+++ b/tests/test_released_results_record_their_abstentions.py
@@ -1,0 +1,80 @@
+"""A released result must not claim full coverage on a run full of abstentions.
+
+``bibtexupdater_dev_public.json`` shipped ``coverage: 1.0`` and
+``num_uncertain: 0`` for a run whose raw output carries 147 ``unconfirmed``
+records; ``test_public`` shipped the same pair against 101. The paper's Coverage
+column said otherwise, so the two artifacts disagreed and the wrong one was the
+one a reader can recompute.
+
+The DR/FPR/F1 triple is deliberately *not* covered here. Those still score
+abstentions as committed-VALID, which is the convention the paper reports, and
+re-scoring them selectively would make ``bibtex-updater`` the one tool in the
+cohort scored on a different basis from the other twenty.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+RESULTS = Path(__file__).resolve().parent.parent / "data/v1.2/baseline_results"
+
+#: Splits whose released result was corrected, and the abstention count in the
+#: raw output behind it. Pinned rather than recomputed: a test that re-derives
+#: its own expectation from the same file cannot catch the file changing.
+EXPECTED_ABSTENTIONS = {"dev_public": 147, "test_public": 101}
+
+
+@pytest.mark.parametrize("split", sorted(EXPECTED_ABSTENTIONS))
+def test_abstentions_are_recorded(split: str):
+    path = RESULTS / f"bibtexupdater_{split}.json"
+    if not path.is_file():
+        pytest.skip(f"{path.name} not present")
+    result = json.loads(path.read_text())
+    assert result["num_uncertain"] == EXPECTED_ABSTENTIONS[split], (
+        f"{path.name} records {result['num_uncertain']} abstentions; the raw output "
+        f"behind it has {EXPECTED_ABSTENTIONS[split]}. Zero is what the pre-fix wrapper "
+        "wrote, by mapping every abstention to a committed VALID."
+    )
+
+
+@pytest.mark.parametrize("split", sorted(EXPECTED_ABSTENTIONS))
+def test_coverage_agrees_with_the_abstention_count(split: str):
+    """Coverage and ``num_uncertain`` must tell the same story.
+
+    They disagreed by construction before: coverage came from the label
+    distribution, which no longer held any UNCERTAIN.
+    """
+    path = RESULTS / f"bibtexupdater_{split}.json"
+    if not path.is_file():
+        pytest.skip(f"{path.name} not present")
+    result = json.loads(path.read_text())
+    n = result["num_entries"]
+    implied = 1.0 - result["num_uncertain"] / n
+    assert result["coverage"] < 1.0, (
+        f"{path.name} claims full coverage while recording {result['num_uncertain']} abstentions"
+    )
+    # Missing records lower coverage further, so the recorded value is at most
+    # the abstention-implied one; a gap wider than 1pp means something else is
+    # unanswered and should be explained rather than absorbed.
+    assert implied - result["coverage"] <= 0.01, (
+        f"{path.name}: coverage {result['coverage']} against {implied:.4f} implied by "
+        f"{result['num_uncertain']} abstentions over {n} entries"
+    )
+
+
+def test_the_triple_still_uses_the_committed_convention():
+    """Pins what this correction deliberately did not touch.
+
+    If these move, the released result has been re-scored selectively and no
+    longer sits on the same basis as the rest of the cohort.
+    """
+    path = RESULTS / "bibtexupdater_dev_public.json"
+    if not path.is_file():
+        pytest.skip("released result not present")
+    result = json.loads(path.read_text())
+    assert result["detection_rate"] == pytest.approx(0.8647, abs=5e-4)
+    assert result["false_positive_rate"] == pytest.approx(0.0916, abs=5e-4)
+    assert result["f1_hallucination"] == pytest.approx(0.8904, abs=5e-4)


### PR DESCRIPTION
`bibtexupdater_dev_public.json` shipped `coverage: 1.0` and `num_uncertain: 0` for a run whose raw output carries **147 `unconfirmed` records**; `test_public` shipped the same pair against **101**. The wrapper (fixed in #49) mapped every abstention to a committed VALID, so the field meant to record them recorded nothing. The paper's Coverage column said otherwise, and the artifact a reader can recompute was the wrong one.

| | released | corrected |
|---|---|---|
| `dev_public` coverage | 1.0 | **0.8624** (147 abstentions) |
| `test_public` coverage | 1.0 | **0.8761** (101 abstentions) |
| DR / FPR / F1 | unchanged | unchanged |

## Why the triple is untouched

Re-scoring it was the first thing I tried, and it is wrong twice over.

**It would not be comparable.** Under the conservative protocol abstentions leave the confusion matrix, so a re-scored `bibtex-updater` is the one tool in the cohort scored selectively while the other twenty are scored committed. It lifted its `test_public` MCC from 0.750 to **0.918** and made it the leader under all three taxonomy-fold scorings — an artifact of dropping the 101 entries it abstained on, not a result. The fold ablation's rank-change counts moved from 14/17 to 11/13 on the same artifact.

**It would not reproduce anyway.** The released runs go through `run_with_prescreening`, whose overrides are absent from the raw JSONL, so a raw-only parse gives DR 0.820 / FPR 0.051 against the released 0.865 / 0.092.

Committed-VALID in the triple with coverage reported beside it *is* the paper's documented convention. The JSON simply never recorded the second half.

## A defect the guard caught

The script checks the raw file's status histogram against the aggregate's own `_btu_status_histogram` and refuses to write when they disagree. That caught something: **`data/v1.2/baseline_results/bibtexupdater_raw_dev_public.jsonl` is a 0.10.0-era run with no `unconfirmed` records at all**, so the raw output shipped beside the aggregate does not correspond to it. The run that does is under `results/relabel_delta/btu_v1_2_0/`. The stale raw file is left in place here rather than swapped, since replacing a released artifact is a separate call.

## Verification

- `validate-results --strict`: passed (manifest checksums rebuilt).
- Freshness gate: exit 0, only the registered `KNOWN_STALE` HaRC file reported.
- Five derived tables regenerated; the CSVs come back **byte-identical**, since coverage is not an input to any of them. Only `tables/provenance.json` changes.
- `tests/test_released_results_record_their_abstentions.py`, 5 cases, including one that pins the triple so a future selective re-score fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp