### PR TITLE
Two defects the first honest baselines run exposed

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -18,7 +18,12 @@ jobs:
   baseline:
     name: Evaluate ${{ matrix.baseline }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 15 was not enough: the doi_only live run resolves all 1,119 dev_public
+    # DOIs serially against doi.org and was cancelled at 15m17s on run
+    # 33915448052, mid-evaluation. It reported as `cancelled` rather than
+    # `failure`, which is the reading a matrix `timeout-minutes` gives a job
+    # that ran out of budget rather than one that broke.
+    timeout-minutes: 30
     # Kept so one throttled baseline does not abort the others -- these hit
     # Semantic Scholar and CrossRef from a shared runner IP and a 429 is
     # routine. The cost is that the workflow's own conclusion stops meaning
@@ -31,7 +36,7 @@ jobs:
       matrix:
         include:
           - baseline: doi_only
-            max_entries: 0       # fast — evaluate all
+            max_entries: 0       # evaluate all; ~20 min against doi.org
             precomputed: false
           - baseline: bibtexupdater
             precomputed: true    # rate-limited — use pre-computed results

--- a/hallmark/evaluation/validate.py
+++ b/hallmark/evaluation/validate.py
@@ -35,6 +35,34 @@ def compute_sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+#: Splits carrying an entry that a result may legitimately not score, and how
+#: many. ``stress_test`` holds 121 hallucinated entries plus a single VALID
+#: contamination canary; with one valid entry the false-positive rate is not a
+#: measurement, so the cascade rows are scored on the 121 and say so in the
+#: paper. The validator had no way to express that, and failed three released
+#: results on it -- which meant the whole ``baselines.yml`` matrix went red the
+#: first time its conclusion was allowed to mean anything.
+#:
+#: Deliberately not a tolerance. An off-by-one allowance would also pass a run
+#: that silently dropped an entry; this permits exactly the documented count.
+CANARY_ENTRIES: dict[str, int] = {"stress_test": 1}
+
+
+def _allowed_entry_counts(split_name: str, expected_total: int | None) -> set[int]:
+    """Entry counts a result may report for *split_name*.
+
+    The split total always, plus the total minus that split's canary entries
+    where a split has any.
+    """
+    if expected_total is None:
+        return set()
+    allowed = {expected_total}
+    canaries = CANARY_ENTRIES.get(split_name)
+    if canaries:
+        allowed.add(expected_total - canaries)
+    return allowed
+
+
 def validate_reference_results(
     results_dir: str | Path,
     metadata_path: str | Path | None = None,
@@ -120,7 +148,8 @@ def validate_reference_results(
             split_name = result.split_name
             if split_name in metadata_splits:
                 expected_total = metadata_splits[split_name].get("total")
-                if expected_total is not None and result.num_entries != expected_total:
+                allowed = _allowed_entry_counts(split_name, expected_total)
+                if expected_total is not None and result.num_entries not in allowed:
                     errors.append(
                         f"{filename}: num_entries={result.num_entries} "
                         f"doesn't match metadata total={expected_total} "

--- a/tests/test_stress_canary_is_not_a_missing_entry.py
+++ b/tests/test_stress_canary_is_not_a_missing_entry.py
@@ -1,0 +1,42 @@
+"""A split's contamination canary is not a dropped entry.
+
+``stress_test`` holds 121 hallucinated entries plus a single VALID canary
+planted to detect contamination. With one valid entry the false-positive rate is
+not a measurement, so the cascade rows are scored on the 121 and the paper says
+so. ``validate-results --metadata`` had no way to express that and failed all
+three released cascade results -- which took the whole ``baselines.yml`` matrix
+red the first time its conclusion was allowed to mean anything (run
+33915448052).
+
+The exemption is exactly one entry, not a tolerance: an off-by-one allowance
+would also pass a run that silently dropped an entry, which is the failure this
+check exists to catch.
+"""
+
+from __future__ import annotations
+
+from hallmark.evaluation.validate import CANARY_ENTRIES, _allowed_entry_counts
+
+
+def test_stress_test_may_omit_its_canary():
+    assert _allowed_entry_counts("stress_test", 122) == {121, 122}
+
+
+def test_a_split_with_no_canary_gets_no_slack():
+    assert _allowed_entry_counts("dev_public", 1119) == {1119}
+    assert 1118 not in _allowed_entry_counts("dev_public", 1119)
+
+
+def test_the_exemption_is_one_entry_not_a_tolerance():
+    """120 is a dropped entry, not a canary, and must still fail."""
+    assert 120 not in _allowed_entry_counts("stress_test", 122)
+
+
+def test_unknown_total_permits_nothing():
+    """A missing metadata total must not read as 'any count is fine'."""
+    assert _allowed_entry_counts("stress_test", None) == set()
+
+
+def test_only_stress_test_is_registered():
+    """Pins the scope. A second entry here needs its own justification."""
+    assert CANARY_ENTRIES == {"stress_test": 1}


### PR DESCRIPTION
Dispatching `baselines.yml` with the #50 gate did exactly what it was for. Run [33915448052](https://github.com/rpatrik96/hallmark/actions/runs/33915448052):

```
OVERALL: cancelled
  Evaluate doi_only:          cancelled
  Evaluate bibtexupdater:     failure
  Evaluate verify_citations:  success
  Evaluate harc:              failure
  Aggregate Results:          success
  Fail if any baseline failed: failure   <- the gate
```

Before the gate, that run reports **success**. Both causes are real.

## 1. The validator cannot express a contamination canary

`validate-results --strict --metadata` failed all three cascade `stress_test` results: `num_entries=121` against a metadata total of 122.

The split holds 121 hallucinated entries plus a single VALID canary planted to detect contamination. With one valid entry the false-positive rate is not a measurement, so the cascade rows are scored on the 121 — and `tab:cascade` says so in the caption. The validator had no way to express that.

Worth noting *where* this hid: the CI invocation passes `--metadata` and the one anybody runs by hand does not, so it failed only in the place nobody was looking, inside a workflow that reported success anyway.

`CANARY_ENTRIES` permits exactly the documented count. Deliberately **not** a tolerance — an off-by-one allowance would also pass a run that silently dropped an entry, which is the failure this check exists to catch. The test pinning that fails under a blanket off-by-one.

## 2. `doi_only` ran out of budget, and it read as `cancelled`

Started 20:17:02, completed 20:32:19 — 15m17s against `timeout-minutes: 15`, cancelled mid-evaluation while resolving all 1,119 `dev_public` DOIs serially against `doi.org`. Raised to 30, and the matrix comment claiming the full run is "fast" is corrected.

The `cancelled` conclusion is worth flagging: a job killed by `timeout-minutes` does not report `failure`, so a timeout is one more way for a run to look like something other than a failure. The gate treats anything that is neither `success` nor `skipped` as a failure, which is why it caught this one.

## Verification

`validate-results --strict --metadata data/v1.2/metadata.json`: **exit 0, Validation passed** (it was exit 1 with 3 errors). 74 passed in the validate/schema/freshness/canary selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp