### PR TITLE
Four holes in the guards the hardening series added

### DIFF
--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -393,6 +393,21 @@ _OUTAGE_RE = re.compile(
 )
 
 
+#: The source-availability report of the most recent bibtex-check run in this
+#: process, or None when it reported none. Set by ``_run_bibtex_check_subprocess``
+#: on every run -- exit 0 included, since bibtex-check prints the same summary
+#: below its 10% threshold -- and copied onto the EvaluationResult by the CLI's
+#: provenance stamp. Before this the report was parsed only to format one log
+#: line, so a run scored under HALLMARK_ALLOW_SOURCE_OUTAGE=1 carried no record
+#: of which sources were dark.
+_last_source_condition: dict[str, object] | None = None
+
+
+def last_source_condition() -> dict[str, object] | None:
+    """The source-availability report of the last bibtex-check run, if any."""
+    return _last_source_condition
+
+
 def parse_source_condition(output: str) -> dict[str, object] | None:
     """Extract bibtex-check's own source-availability report, if it made one.
 
@@ -756,6 +771,8 @@ def _run_bibtex_check_subprocess(
     academic_only: bool = True,
 ) -> list[Prediction]:
     """Run bibtex-check subprocess and return raw predictions (no pre-screening)."""
+    global _last_source_condition
+    _last_source_condition = None
     start_time = time.time()
 
     # Use a directory we control to avoid cleanup race on timeout
@@ -810,8 +827,9 @@ def _run_bibtex_check_subprocess(
                 text=True,
                 timeout=timeout,
             )
+            condition = parse_source_condition(result.stdout + result.stderr)
+            _last_source_condition = condition
             if result.returncode == EXIT_SOURCE_OUTAGE:
-                condition = parse_source_condition(result.stdout + result.stderr)
                 detail = ""
                 if condition:
                     detail = (

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -224,6 +224,9 @@ def _aggressive_fallback(pred: Prediction) -> Prediction:
         source=pred.source,
         predicted_hallucination_type="plausible_fabrication",
         cascade_stage=pred.cascade_stage,
+        # A promoted fallback is still a fallback: without this an all-fallback
+        # run becomes detection rate 1.0 with every entry marked evaluated.
+        evaluated=pred.evaluated,
     )
 
 

--- a/hallmark/baselines/common.py
+++ b/hallmark/baselines/common.py
@@ -149,6 +149,9 @@ def run_baseline_both_variants(
                     confidence=0.5,
                     reason="Entry not in tool output",
                     source="tool",
+                    # Same manufactured placeholder as run_with_prescreening's
+                    # backfill, and the path that produced the four null ablations.
+                    evaluated=False,
                 )
             )
 

--- a/hallmark/baselines/harc.py
+++ b/hallmark/baselines/harc.py
@@ -274,9 +274,10 @@ def _run_harc_batches(
     # ``checked`` set, and the run lands at zero having made real HTTP requests
     # during pre-screening -- which is why the failure reads as a clean result.
     if entries and checked_count == 0:
-        # Every entry will be backfilled, and every backfill now carries
-        # evaluated=False, so the run reports num_evaluated 0 and the metrics
-        # layer refuses to read it as a measurement. Log loudly and return: the
+        # Every entry will be backfilled, and every backfill carries
+        # evaluated=False, so the run reports num_evaluated 0, evaluate() logs
+        # it at ERROR, and `hallmark evaluate --output` refuses to write it
+        # unless --allow-null-run is passed. Log loudly and return: the
         # predictions are still wanted by callers that want to see the shape of
         # the failure, and refusing outright would also discard a partial run.
         logger.error(

--- a/hallmark/baselines/prescreening.py
+++ b/hallmark/baselines/prescreening.py
@@ -630,7 +630,9 @@ def merge_with_predictions(
     """Merge pre-screening results with tool predictions.
 
     Logic:
-    - If pre-screening found HALLUCINATED and tool said VALID → override to HALLUCINATED
+    - If pre-screening found HALLUCINATED and tool said VALID or abstained (UNCERTAIN)
+      → override to HALLUCINATED. An abstention is not a verdict, so a local
+      detection outranks it exactly as it outranks a committed VALID.
     - If both say HALLUCINATED → keep higher confidence
     - If pre-screening says UNKNOWN → keep tool prediction unchanged
     - For entries with no tool prediction (timeout/missing) → use pre-screening if available
@@ -671,6 +673,8 @@ def merge_with_predictions(
                         wall_clock_seconds=0.0,
                         api_calls=0,
                         source="prescreening",
+                        # The tool returned nothing for this entry.
+                        evaluated=False,
                     )
                 )
             else:
@@ -686,12 +690,16 @@ def merge_with_predictions(
                         wall_clock_seconds=0.0,
                         api_calls=0,
                         source="prescreening",
+                        evaluated=False,
                     )
                 )
         else:
             # Tool prediction exists
-            if strongest_hallucinated and tool_pred.label == "VALID":
-                # Override: pre-screening found hallucination, tool said valid
+            if strongest_hallucinated and tool_pred.label in ("VALID", "UNCERTAIN"):
+                # Override: pre-screening found a hallucination and the tool
+                # either cleared the entry or abstained on it. Since #49 an
+                # abstention arrives as UNCERTAIN; overriding only VALID dropped
+                # 25 + 19 detections on the public splits.
                 merged.append(
                     Prediction(
                         bibtex_key=key,
@@ -706,6 +714,9 @@ def merge_with_predictions(
                         wall_clock_seconds=tool_pred.wall_clock_seconds,
                         api_calls=tool_pred.api_calls,
                         source="prescreening_override",
+                        # Pre-screening is a benchmark-side check, not the tool:
+                        # whether the tool ran for this entry is unchanged.
+                        evaluated=tool_pred.evaluated,
                     )
                 )
             elif strongest_hallucinated and tool_pred.label == "HALLUCINATED":
@@ -725,6 +736,7 @@ def merge_with_predictions(
                             wall_clock_seconds=tool_pred.wall_clock_seconds,
                             api_calls=tool_pred.api_calls,
                             source="tool",
+                            evaluated=tool_pred.evaluated,
                         )
                     )
                 else:
@@ -743,6 +755,7 @@ def merge_with_predictions(
                             wall_clock_seconds=tool_pred.wall_clock_seconds,
                             api_calls=tool_pred.api_calls,
                             source="tool",
+                            evaluated=tool_pred.evaluated,
                         )
                     )
             else:

--- a/hallmark/baselines/registry.py
+++ b/hallmark/baselines/registry.py
@@ -776,6 +776,7 @@ def _register_builtins() -> None:
     def _run_random(entries: list[BlindEntry], **kw: Any) -> list[Prediction]:
         from hallmark.baselines.degenerate import random_baseline
 
+        kw.pop("split", None)  # dispatch-level; the baseline does not use it
         return random_baseline(entries, **kw)
 
     register(
@@ -819,6 +820,7 @@ def _register_builtins() -> None:
     def _run_venue_oracle(entries: list[BlindEntry], **kw: Any) -> list[Prediction]:
         from hallmark.baselines.degenerate import venue_oracle_baseline
 
+        kw.pop("split", None)  # dispatch-level; the baseline does not use it
         return venue_oracle_baseline(entries, **kw)
 
     register(
@@ -835,6 +837,7 @@ def _register_builtins() -> None:
 
     # --- Ensemble ---
     def _run_ensemble(entries: list[BlindEntry], **kw: Any) -> list[Prediction]:
+        from hallmark.baselines.bibtexupdater import SourceOutageError
         from hallmark.baselines.ensemble import ensemble_predict
 
         # Default: combine doi_only + bibtexupdater
@@ -848,6 +851,11 @@ def _register_builtins() -> None:
                     dep_info = _REGISTRY[dep_name]
                     dep_kwargs = dict(dep_info.runner_kwargs)
                     strategy_preds[dep_name] = dep_info.runner(entries, **dep_kwargs)
+                except SourceOutageError:
+                    # The component disowned its run. Dropping it here would
+                    # score doi_only alone under the ensemble's name -- which
+                    # is what happened with DBLP down on 2026-09-05.
+                    raise
                 except Exception as e:
                     logger.warning(f"Ensemble: skipping {dep_name}: {e}")
 
@@ -855,6 +863,7 @@ def _register_builtins() -> None:
             logger.error("Ensemble: no component baselines available")
             return fallback_predictions(entries, reason="Ensemble: no components")
 
+        kw.pop("split", None)  # dispatch-level; the ensemble does not use it
         return ensemble_predict(entries, strategy_preds, **kw)
 
     register(

--- a/hallmark/cli.py
+++ b/hallmark/cli.py
@@ -103,6 +103,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to predictions JSONL file (alternative to --baseline)",
     )
     eval_parser.add_argument("--output", type=str, help="Path to write evaluation results JSON")
+    eval_parser.add_argument(
+        "--allow-null-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Write the result even when the tool evaluated none of the entries. "
+            "By default such a run is refused: its detection rate and false-positive "
+            "rate are artefacts of the tool not running, not measurements."
+        ),
+    )
     eval_parser.add_argument("--data-dir", type=str, help="Override data directory")
     eval_parser.add_argument("--version", default="v1.2", help="Dataset version")
     eval_parser.add_argument(
@@ -557,6 +567,12 @@ def _stamp_provenance(result: EvaluationResult, args: argparse.Namespace) -> Non
                 result.tool_version = f"bibtex-updater {version}"
         except (ImportError, OSError) as exc:  # pragma: no cover - best effort
             logging.debug("Could not probe bibtex-check version: %s", exc)
+        try:
+            from hallmark.baselines.bibtexupdater import last_source_condition
+
+            result.source_condition = last_source_condition()
+        except ImportError as exc:  # pragma: no cover - best effort
+            logging.debug("Could not read the source condition: %s", exc)
 
     split = getattr(args, "split", None)
     if not split:
@@ -947,6 +963,18 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
 
         _save_predictions(predictions, args.save_predictions)
         logging.info(f"Predictions written to {args.save_predictions}")
+
+    # A run that evaluated nothing is not a measurement. evaluate() has already
+    # said so at ERROR; refusing here is what stops it becoming a results file
+    # that the leaderboard ranks and the history log records.
+    if result.num_evaluated == 0 and result.num_entries > 0 and not args.allow_null_run:
+        print(
+            f"error: {result.tool_name} evaluated 0 of {result.num_entries} entries on "
+            f"{result.split_name}; every prediction is a fallback, so this is not a "
+            "measurement and will not be written. Pass --allow-null-run to write it anyway.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Save results
     if args.output:

--- a/hallmark/dataset/schema.py
+++ b/hallmark/dataset/schema.py
@@ -551,6 +551,11 @@ class EvaluationResult:
     # does not preserve mtimes, so on any fresh clone that check reads checkout
     # order rather than staleness.
     tool_version: str | None = None
+    # bibtex-check's own source-availability report for the run that produced
+    # this result, when it made one: entries with an incomplete lookup, the
+    # total, the fraction, and per-source failure counts. Availability moves
+    # outcomes, so it belongs beside the numbers rather than only in a log.
+    source_condition: dict[str, object] | None = None
     split_sha256: str | None = None
     run_timestamp: str | None = None
 

--- a/hallmark/evaluation/metrics.py
+++ b/hallmark/evaluation/metrics.py
@@ -2033,6 +2033,8 @@ def _make_aggressive_predictions(
                     label="HALLUCINATED",
                     confidence=0.55,
                     reason="[aggressive mode: missing prediction treated as HALLUCINATED]",
+                    # The tool produced nothing for this entry.
+                    evaluated=False,
                 )
             )
         elif pred.label == "UNCERTAIN":
@@ -2050,6 +2052,7 @@ def _make_aggressive_predictions(
                     source=pred.source,
                     predicted_hallucination_type=pred.predicted_hallucination_type,
                     cascade_stage=pred.cascade_stage,
+                    evaluated=pred.evaluated,
                 )
             )
         else:

--- a/tests/test_baseline_split_kwarg.py
+++ b/tests/test_baseline_split_kwarg.py
@@ -91,3 +91,74 @@ def test_baseline_runner_tolerates_split_kwarg(name: str) -> None:
         "'split' kwarg that registry.run_baseline forwards. Add '**_kw: object' "
         "to its signature (see run_doi_only) or pop 'split' in the wrapper."
     )
+
+
+# --- Every wrapper, not only the ones that import a ``run_*`` function ---------
+
+
+def _forwarding_targets() -> dict[str, list[tuple[str, str]]]:
+    """Map each ``_run_*`` wrapper to the imported callables it forwards ``**kw`` into.
+
+    The map above follows only aliases named ``run_*``, which is how three
+    wrappers -- ``random``, ``venue_oracle``, ``ensemble`` -- delegated ``**kw``
+    into functions with no ``split`` parameter and stayed green: they import
+    ``random_baseline``, ``venue_oracle_baseline`` and ``ensemble_predict``.
+    """
+    tree = ast.parse(pathlib.Path(R.__file__).read_text())
+    out: dict[str, list[tuple[str, str]]] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name.startswith("_run")):
+            continue
+        if _wrapper_consumes_split(node):
+            continue
+        imported = {
+            alias.asname or alias.name: (sub.module, alias.name)
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.ImportFrom) and sub.module
+            for alias in sub.names
+        }
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            forwards = any(k.arg is None for k in call.keywords)  # ``**kw`` splat
+            if not forwards or not isinstance(call.func, ast.Name):
+                continue
+            if call.func.id in imported:
+                out.setdefault(node.name, []).append(imported[call.func.id])
+    return out
+
+
+_FORWARDING = _forwarding_targets()
+
+
+def test_the_forwarding_map_is_not_empty() -> None:
+    assert _FORWARDING, "no wrapper forwards **kw to an imported callable -- the AST walk broke"
+
+
+@pytest.mark.parametrize("wrapper", sorted(_FORWARDING))
+def test_every_forwarded_callable_tolerates_split(wrapper: str) -> None:
+    for module_name, fn_name in _FORWARDING[wrapper]:
+        fn = getattr(importlib.import_module(module_name), fn_name)
+        assert _accepts_split(fn, None), (
+            f"{wrapper} forwards **kw (which carries 'split') into "
+            f"{module_name}.{fn_name}{inspect.signature(fn)}, which rejects it. "
+            "Pop 'split' in the wrapper or accept **_kw in the callee."
+        )
+
+
+@pytest.mark.parametrize("name", ["random", "venue_oracle", "always_valid", "always_hallucinated"])
+def test_offline_baselines_run_with_split_set(name: str) -> None:
+    """The dispatch path the CLI always takes, on baselines that need no network."""
+    from hallmark.dataset.schema import BenchmarkEntry
+
+    entries = [
+        BenchmarkEntry(
+            bibtex_key=f"e{i}",
+            bibtex_type="article",
+            fields={"title": f"T{i}", "year": "2020"},
+            label="VALID",
+        )
+        for i in range(3)
+    ]
+    preds = R.run_baseline(name, entries, split="dev_public")
+    assert len(preds) == 3

--- a/tests/test_cli_refuses_a_null_run.py
+++ b/tests/test_cli_refuses_a_null_run.py
@@ -1,0 +1,77 @@
+"""``hallmark evaluate --output`` must not write a run that evaluated nothing.
+
+``evaluate()`` logs an error when every prediction is a fallback and then returns
+a complete ``EvaluationResult`` with detection rate 0.0 and false-positive rate
+0.0. Nothing downstream read ``num_evaluated``, so the CLI wrote that result to
+disk like any other, the leaderboard ranked it, and the history log recorded it.
+Four pre-screening ablations shipped that way. Refusing at the write is the
+cheapest place to stop it; ``--allow-null-run`` exists for looking at the shape
+of a failure on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hallmark import cli
+from hallmark.baselines.common import fallback_predictions
+
+
+@pytest.fixture
+def null_baseline(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_run_baseline",
+        lambda name, entries, split=None, **kw: fallback_predictions(
+            entries, reason="Fallback: tool unavailable"
+        ),
+    )
+
+
+def _argv(out: Path, *extra: str) -> list[str]:
+    return [
+        "evaluate",
+        "--split",
+        "dev_public",
+        "--baseline",
+        "doi_only",
+        "--max-entries",
+        "6",
+        "--output",
+        str(out),
+        *extra,
+    ]
+
+
+def test_a_null_run_is_not_written(null_baseline, tmp_path, capsys):
+    out = tmp_path / "null.json"
+    rc = cli.main(_argv(out))
+    assert rc != 0
+    assert not out.exists(), "a run that evaluated nothing must not become a results file"
+    assert "--allow-null-run" in capsys.readouterr().err
+
+
+def test_the_override_writes_it_and_the_file_says_so(null_baseline, tmp_path):
+    out = tmp_path / "null.json"
+    rc = cli.main(_argv(out, "--allow-null-run"))
+    assert rc == 0
+    payload = json.loads(out.read_text())
+    assert payload["num_evaluated"] == 0
+
+
+def test_a_real_run_is_unaffected(monkeypatch, tmp_path):
+    from hallmark.dataset.schema import Prediction
+
+    monkeypatch.setattr(
+        cli,
+        "_run_baseline",
+        lambda name, entries, split=None, **kw: [
+            Prediction(bibtex_key=e.bibtex_key, label="VALID", confidence=0.9) for e in entries
+        ],
+    )
+    out = tmp_path / "real.json"
+    assert cli.main(_argv(out)) == 0
+    assert json.loads(out.read_text())["num_evaluated"] == 6

--- a/tests/test_evaluated_flag_survives_rebuilds.py
+++ b/tests/test_evaluated_flag_survives_rebuilds.py
@@ -1,0 +1,131 @@
+"""``Prediction.evaluated`` must survive every place a prediction is rebuilt.
+
+The flag says the tool never ran for an entry. Four code paths copy a prediction
+field by field into a new ``Prediction`` and were written before the field
+existed, so they reset it to the default ``True``: pre-screening's override and
+confirm branches, the cascade's aggressive promotion, the aggressive eval-mode
+remap, and the both-variants backfill. Through any of them a run that measured
+nothing comes out looking measured. The worst case is the cascade's promotion,
+which turns an all-fallback run into an all-HALLUCINATED run at detection rate
+1.0 with every entry marked evaluated.
+"""
+
+from __future__ import annotations
+
+from hallmark.baselines.cascade import _aggressive_fallback
+from hallmark.baselines.common import fallback_predictions, run_with_prescreening
+from hallmark.baselines.prescreening import PreScreenResult, merge_with_predictions
+from hallmark.dataset.schema import BenchmarkEntry, BlindEntry, Prediction
+from hallmark.evaluation.metrics import _make_aggressive_predictions, run_evaluated_nothing
+
+
+def _blind(key: str) -> BlindEntry:
+    return BlindEntry(bibtex_key=key, bibtex_type="article", fields={"title": key, "year": "2020"})
+
+
+def _hit(key: str, confidence: float = 0.95) -> list[PreScreenResult]:
+    return [PreScreenResult("HALLUCINATED", confidence, "Fake DOI prefix", "doi_check")]
+
+
+def _unevaluated(key: str, label: str = "VALID", confidence: float = 0.5) -> Prediction:
+    return Prediction(
+        bibtex_key=key, label=label, confidence=confidence, reason="backfill", evaluated=False
+    )
+
+
+class TestPrescreeningMergeKeepsTheFlag:
+    def test_override_of_an_unevaluated_valid_stays_unevaluated(self):
+        merged = merge_with_predictions([_blind("a")], [_unevaluated("a")], {"a": _hit("a")})
+        assert merged[0].label == "HALLUCINATED"
+        assert merged[0].evaluated is False
+
+    def test_confirm_with_stronger_prescreening_stays_unevaluated(self):
+        tool = _unevaluated("a", label="HALLUCINATED", confidence=0.6)
+        merged = merge_with_predictions([_blind("a")], [tool], {"a": _hit("a", 0.95)})
+        assert merged[0].evaluated is False
+
+    def test_confirm_with_stronger_tool_stays_unevaluated(self):
+        tool = _unevaluated("a", label="HALLUCINATED", confidence=0.99)
+        merged = merge_with_predictions([_blind("a")], [tool], {"a": _hit("a", 0.6)})
+        assert merged[0].evaluated is False
+
+    def test_an_entry_the_tool_never_returned_is_unevaluated(self):
+        with_hit = merge_with_predictions([_blind("a")], [], {"a": _hit("a")})
+        without = merge_with_predictions([_blind("b")], [], {})
+        assert with_hit[0].evaluated is False
+        assert without[0].evaluated is False
+
+    def test_a_real_prediction_stays_evaluated(self):
+        real = Prediction(bibtex_key="a", label="VALID", confidence=0.9, reason="verified")
+        merged = merge_with_predictions([_blind("a")], [real], {"a": _hit("a")})
+        assert merged[0].evaluated is True
+
+
+def test_a_null_run_with_prescreening_on_is_still_a_null_run():
+    """The default HaRC path: every batch times out, pre-screening flags some.
+
+    Pre-screening is a benchmark-side check, not the tool. Its detections are
+    recorded in ``source``; they must not make the tool look like it ran.
+    """
+    entries = [_blind("a"), _blind("b"), _blind("c")]
+    hits = {"a": _hit("a")}
+    import hallmark.baselines.prescreening as ps
+
+    original = ps.prescreen_entries
+    ps.prescreen_entries = lambda es, reference_year=None: hits
+    try:
+        preds = run_with_prescreening(entries, lambda es: [], skip_prescreening=False)
+    finally:
+        ps.prescreen_entries = original
+    by_key = {p.bibtex_key: p for p in preds}
+    assert by_key["a"].label == "HALLUCINATED" and by_key["a"].source == "prescreening_override"
+    assert all(p.evaluated is False for p in preds)
+    assert run_evaluated_nothing(preds) is True
+
+
+def test_the_cascades_aggressive_promotion_keeps_the_flag():
+    fallback = fallback_predictions([_blind("a")], reason="Fallback: tool unavailable")[0]
+    promoted = _aggressive_fallback(fallback)
+    assert promoted.label == "HALLUCINATED"
+    assert promoted.evaluated is False, "a null run must not become DR 1.0 of evaluated detections"
+
+
+class TestAggressiveEvalModeKeepsTheFlag:
+    def _entries(self) -> list[BenchmarkEntry]:
+        return [
+            BenchmarkEntry(
+                bibtex_key=k,
+                bibtex_type="article",
+                fields={"title": k},
+                label="HALLUCINATED",
+                hallucination_type="fabricated_doi",
+                difficulty_tier=1,
+            )
+            for k in ("a", "b")
+        ]
+
+    def test_an_unevaluated_uncertain_stays_unevaluated_when_remapped(self):
+        remapped = _make_aggressive_predictions(
+            self._entries(),
+            [_unevaluated("a", label="UNCERTAIN"), _unevaluated("b", label="UNCERTAIN")],
+        )
+        assert all(p.label == "HALLUCINATED" for p in remapped)
+        assert all(p.evaluated is False for p in remapped)
+
+    def test_a_missing_prediction_is_synthesised_as_unevaluated(self):
+        remapped = _make_aggressive_predictions(self._entries(), [])
+        assert all(p.evaluated is False for p in remapped)
+
+
+def test_both_variants_backfill_is_marked_unevaluated():
+    import hallmark.baselines.prescreening as ps
+    from hallmark.baselines.common import run_baseline_both_variants
+
+    original = ps.prescreen_entries
+    ps.prescreen_entries = lambda es, reference_year=None: {}
+    try:
+        both = run_baseline_both_variants([_blind("a"), _blind("b")], lambda es: [])
+    finally:
+        ps.prescreen_entries = original
+    assert all(p.evaluated is False for p in both["without_prescreening"])
+    assert run_evaluated_nothing(both["without_prescreening"]) is True

--- a/tests/test_harc_timeout_is_not_a_result.py
+++ b/tests/test_harc_timeout_is_not_a_result.py
@@ -46,8 +46,9 @@ def test_a_run_that_checked_nothing_is_marked_unevaluated(monkeypatch):
     """Every batch timing out is a failed run, not a run with no findings.
 
     Originally this asserted a RuntimeError. Refusing outright also discarded
-    partial runs, so the run now returns predictions carrying evaluated=False
-    and the metrics layer declines to score them.
+    partial runs, so the run now returns predictions carrying evaluated=False;
+    evaluate() logs the null run at ERROR and the CLI refuses to write it
+    (tests/test_cli_refuses_a_null_run.py).
     """
     monkeypatch.setattr(harc, "_run_harcx_batch", lambda *a, **k: ({}, set(), True))
     preds = harc._run_harc_batches(

--- a/tests/test_prescreening_overrides_an_abstention.py
+++ b/tests/test_prescreening_overrides_an_abstention.py
@@ -1,0 +1,83 @@
+"""Pre-screening must be able to override an abstention.
+
+Since #49, bibtex-updater's abstentions parse to ``UNCERTAIN`` instead of a
+committed ``VALID``. ``merge_with_predictions`` only ever overrode ``VALID``, so
+a fake DOI or a future year that pre-screening had found was dropped whenever
+the tool had abstained on that entry. On the released raw runs that is 25 true
+positives on ``dev_public`` and 19 on ``test_public`` -- all ``unconfirmed``,
+all gold HALLUCINATED -- that a fresh run under the new mapping loses. The
+cascade compounds it: the status dict never says ``prescreening_override`` for
+them, so they route to Stage 2 and spend LLM budget on a verdict the local
+check had already reached.
+"""
+
+from __future__ import annotations
+
+from hallmark.baselines import bibtexupdater
+from hallmark.baselines.prescreening import PreScreenResult, merge_with_predictions
+from hallmark.dataset.schema import BlindEntry, Prediction
+
+
+def _entry(key: str = "k1") -> BlindEntry:
+    return BlindEntry(bibtex_key=key, bibtex_type="article", fields={"title": "T", "year": "2031"})
+
+
+def _abstention(key: str = "k1") -> Prediction:
+    return Prediction(
+        bibtex_key=key,
+        label="UNCERTAIN",
+        confidence=0.5,
+        reason="Status: unconfirmed; Abstention: no source answered, so this is not a verdict",
+    )
+
+
+def _hit(key: str = "k1") -> dict[str, list[PreScreenResult]]:
+    return {
+        key: [
+            PreScreenResult(
+                label="HALLUCINATED",
+                confidence=0.95,
+                reason="Future year 2031",
+                check_name="year_bounds",
+            )
+        ]
+    }
+
+
+def test_an_abstention_is_overridden_by_a_prescreening_detection():
+    merged = merge_with_predictions([_entry()], [_abstention()], _hit())
+    assert merged[0].label == "HALLUCINATED"
+    assert merged[0].source == "prescreening_override"
+    assert "Future year 2031" in merged[0].reason
+
+
+def test_an_abstention_with_no_prescreening_signal_stays_an_abstention():
+    no_signal = {"k1": [PreScreenResult("UNKNOWN", 0.0, "no signal", "doi_check")]}
+    merged = merge_with_predictions([_entry()], [_abstention()], no_signal)
+    assert merged[0].label == "UNCERTAIN"
+
+
+def test_a_committed_valid_is_still_overridden():
+    """The pre-existing behaviour, pinned so the fix does not narrow it."""
+    valid = Prediction(bibtex_key="k1", label="VALID", confidence=0.9, reason="Status: verified")
+    merged = merge_with_predictions([_entry()], [valid], _hit())
+    assert merged[0].label == "HALLUCINATED"
+    assert merged[0].source == "prescreening_override"
+
+
+def test_the_status_dict_reports_the_override_so_the_cascade_credits_it(monkeypatch):
+    """``run_bibtex_check_with_status`` must say ``prescreening_override``.
+
+    ``cascade._stage1_predict`` honours that status as a Stage 1 verdict and
+    routes ``unconfirmed`` to Stage 2; which one the entry gets is decided here.
+    """
+    monkeypatch.setattr(
+        bibtexupdater, "_run_bibtex_check_subprocess", lambda entries, **kw: [_abstention()]
+    )
+    monkeypatch.setattr(
+        "hallmark.baselines.prescreening.prescreen_entries",
+        lambda entries, reference_year=None: _hit(),
+    )
+    predictions, status = bibtexupdater.run_bibtex_check_with_status([_entry()])
+    assert predictions[0].label == "HALLUCINATED"
+    assert status["k1"] == "prescreening_override"

--- a/tests/test_source_outage_is_not_scored.py
+++ b/tests/test_source_outage_is_not_scored.py
@@ -21,12 +21,21 @@ in one day, which is why the fix records the condition rather than only refusing
 
 from __future__ import annotations
 
+import subprocess
+from argparse import Namespace
+
 import pytest
 
+from hallmark.baselines import registry as R
 from hallmark.baselines.bibtexupdater import (
+    ALLOW_OUTAGE_ENV,
     EXIT_SOURCE_OUTAGE,
+    SourceOutageError,
+    last_source_condition,
     parse_source_condition,
+    run_bibtex_check,
 )
+from hallmark.dataset.schema import BenchmarkEntry, BlindEntry, EvaluationResult
 
 #: bibtex-check's actual output from the 2026-09-04 dblp outage.
 REAL_OUTAGE_OUTPUT = """\
@@ -81,3 +90,111 @@ class TestSourceConditionParsing:
 def test_the_exit_code_is_the_one_the_tool_documents():
     """Pinned because the whole guard keys on it."""
     assert EXIT_SOURCE_OUTAGE == 5
+
+
+# --- Through the subprocess, not only the regex -----------------------------------
+
+
+def _entries(n: int = 3) -> list[BlindEntry]:
+    return [
+        BlindEntry(bibtex_key=f"e{i}", bibtex_type="article", fields={"title": f"T{i}"})
+        for i in range(n)
+    ]
+
+
+@pytest.fixture
+def fake_bibtex_check(monkeypatch):
+    """Drive ``_run_bibtex_check_subprocess`` with a canned exit code and output."""
+    from hallmark.baselines import bibtexupdater as btu
+
+    monkeypatch.setattr(btu, "resolve_bibtex_check_bin", lambda: "/fake/bibtex-check")
+    monkeypatch.setattr(btu, "bibtex_check_version", lambda binary=None: "1.2.0")
+    monkeypatch.delenv(ALLOW_OUTAGE_ENV, raising=False)
+
+    def _install(returncode: int, output: str):
+        def _run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, returncode, stdout=output, stderr="")
+
+        monkeypatch.setattr(btu.subprocess, "run", _run)
+
+    return _install
+
+
+def test_exit_5_raises_through_the_public_runner(fake_bibtex_check):
+    fake_bibtex_check(EXIT_SOURCE_OUTAGE, REAL_OUTAGE_OUTPUT)
+    with pytest.raises(SourceOutageError, match="285 of 1119"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_scoring_an_outage_on_purpose_records_the_condition(fake_bibtex_check, monkeypatch):
+    fake_bibtex_check(EXIT_SOURCE_OUTAGE, REAL_OUTAGE_OUTPUT)
+    monkeypatch.setenv(ALLOW_OUTAGE_ENV, "1")
+    preds = run_bibtex_check(_entries(), skip_prescreening=True)
+    assert len(preds) == 3, "the override scores the run"
+    cond = last_source_condition()
+    assert cond is not None
+    assert cond["per_source_failures"] == {"dblp": 275, "openalex": 26}
+
+
+def test_a_sub_threshold_outage_is_recorded_even_though_the_tool_exits_0(fake_bibtex_check):
+    """bibtex-check prints the same summary below its 10% threshold and exits 0."""
+    fake_bibtex_check(
+        0,
+        "WARNING: 5 of 50 entries (10.0%) had at least one source lookup that did not "
+        "complete: dblp (5). Those entries report api_error, not not_found.\n",
+    )
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    cond = last_source_condition()
+    assert cond is not None and cond["entries_with_incomplete_lookups"] == 5
+
+
+def test_a_healthy_run_clears_the_condition(fake_bibtex_check):
+    fake_bibtex_check(0, "INFO: Loaded 3 entries\nINFO: done\n")
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    assert last_source_condition() is None
+
+
+def test_the_condition_lands_on_the_result(fake_bibtex_check, monkeypatch):
+    """Where a reader of the JSON will find it: beside the numbers."""
+    from hallmark.cli import _stamp_provenance
+
+    fake_bibtex_check(EXIT_SOURCE_OUTAGE, REAL_OUTAGE_OUTPUT)
+    monkeypatch.setenv(ALLOW_OUTAGE_ENV, "1")
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    result = EvaluationResult(
+        tool_name="bibtexupdater",
+        split_name="dev_public",
+        num_entries=3,
+        num_hallucinated=1,
+        num_valid=2,
+        detection_rate=0.0,
+        false_positive_rate=0.0,
+        f1_hallucination=0.0,
+        tier_weighted_f1=0.0,
+    )
+    _stamp_provenance(result, Namespace(baseline="bibtexupdater", split=None))
+    assert result.source_condition == last_source_condition()
+    assert result.to_dict()["source_condition"]["entries_total"] == 1119
+
+
+def test_the_ensemble_does_not_swallow_an_outage(monkeypatch):
+    """A component that disowned its run must not be silently dropped.
+
+    Observed live: with DBLP down, ``ensemble`` logged "skipping bibtexupdater"
+    and scored ``doi_only`` alone under the ensemble's name.
+    """
+    monkeypatch.setattr(R, "check_available", lambda name: (True, ""))
+
+    def _outage(entries, **kw):
+        raise SourceOutageError("bibtex-check reported a source outage (exit 5)")
+
+    monkeypatch.setattr(R._REGISTRY["doi_only"], "runner", lambda entries, **kw: [])
+    monkeypatch.setattr(R._REGISTRY["bibtexupdater"], "runner", _outage)
+    entries = [
+        BenchmarkEntry(
+            bibtex_key=f"e{i}", bibtex_type="article", fields={"title": f"T{i}"}, label="VALID"
+        )
+        for i in range(3)
+    ]
+    with pytest.raises(SourceOutageError):
+        R.run_baseline("ensemble", entries)


### PR DESCRIPTION
Four defects found by a critical pass over #36–#55, each verified by running the code before it was fixed. Every fix has a test that failed first.

## 1. Pre-screening could not override an abstention

Since #49 bibtex-updater's abstentions parse to `UNCERTAIN`. `merge_with_predictions` only ever overrode a committed `VALID`, so a fake DOI or a future year that pre-screening had found was dropped whenever the tool abstained on that entry.

| split | overrides on abstentions in the released raw run | gold label |
|---|---|---|
| `dev_public` | 25 | all HALLUCINATED |
| `test_public` | 19 | all HALLUCINATED |

Forty-four true positives a fresh run under the new mapping loses. The status dict never said `prescreening_override` for them either, so the cascade routed them to Stage 2 and spent LLM budget on a verdict the local check had reached. An abstention is not a verdict; a local detection now outranks it exactly as it outranks a `VALID`. Released numbers are untouched only because they predate #49.

## 2. `evaluated` did not survive being rebuilt

Four code paths copy a prediction field by field into a new `Prediction` and were written before the field existed: pre-screening's override and confirm branches, the cascade's aggressive fallback, the aggressive eval-mode remap, and `run_baseline_both_variants`' backfill (the path that produced the four null ablations). Through any of them a run that measured nothing came out marked measured. Through the cascade's promotion an all-fallback run became **detection rate 1.0** with every entry evaluated.

And nothing refused to write such a run: `evaluate()` logged and returned a complete result, the CLI saved it, `validate-results` never read `num_evaluated`. The comment in `harc.py` that justified replacing the old `RuntimeError` with a log line said "the metrics layer refuses to read it as a measurement"; no layer did. `hallmark evaluate --output` now refuses a run with `num_evaluated == 0` unless `--allow-null-run` is passed.

## 3. Three baselines raised `TypeError` on `split`

`random`, `venue_oracle` and `ensemble` forwarded `**kw` into functions with no `split` parameter, the defect #50 fixed for `verify_citations`. Its gate followed only wrappers that import a `run_*` function, which is **14 of 50** registered baselines. It now follows every imported callable a wrapper forwards `**kw` into, and the offline baselines are dispatched live through `run_baseline` with `split` set.

## 4. The outage report was parsed and thrown away

`parse_source_condition` formatted one log line and nothing else, so a run scored under `HALLMARK_ALLOW_SOURCE_OUTAGE=1` recorded nothing about which sources were dark, and sub-threshold outages (bibtex-check prints the same summary below its 10% threshold and exits 0) were never parsed. The condition is now kept per run and stamped onto the `EvaluationResult` as `source_condition`. The exit-5 path also had no test through the subprocess; it does now.

The ensemble wrapper's broad `except` swallowed `SourceOutageError` and scored `doi_only` alone under the ensemble's name. Observed live while writing this, with DBLP down.

## Left out on purpose

The abstention reason text still says "no source answered" for `skipped` and the `strict_warn_*` statuses, and `strict_warn_cnv` is a relabelled `not_found`/`unconfirmed` in bibtex-updater, so treating it wholesale as an abstention surrenders the `not_found` detections under `--strict-warn-cnv`. No released histogram contains those statuses; flagged, not fixed here.

## Verification

Full suite 1,493 passed, 2 skipped. ruff and mypy clean. The five new or extended test modules fail on `main` in 11 places for the reasons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp