### PR TITLE
The canary allowance checks identity, and CI fetches what its guard reads

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -40,8 +40,13 @@ jobs:
             precomputed: false
           - baseline: bibtexupdater
             precomputed: true    # rate-limited — use pre-computed results
-          - baseline: harc
-            precomputed: true    # rate-limited — use pre-computed results
+          # harc is out of the matrix until it has a current pre-computed result.
+          # harc_dev_public.json was withdrawn on 2026-09-04 (a truncated run),
+          # and harc_with_s2key_dev_public.json is registered known-stale in
+          # scripts/check_results_freshness.py. Until then the leg copied a file
+          # that did not exist and reported success -- run 33948051695 -- which
+          # the #50 gate cannot see, because the job's conclusion was honest
+          # about a step that had been told to swallow its own failure.
           - baseline: verify_citations
             max_entries: 50      # API-dependent — stratified sample
             precomputed: false
@@ -91,8 +96,14 @@ jobs:
             --metadata data/v1.2/metadata.json \
             --strict
           mkdir -p results
-          cp data/v1.2/baseline_results/${{ matrix.baseline }}_${{ inputs.split || 'dev_public' }}.json \
-            results/ 2>/dev/null || echo "No pre-computed result for ${{ matrix.baseline }} on ${{ inputs.split || 'dev_public' }}"
+          # A precomputed leg with nothing to copy has evaluated nothing; it must
+          # not report success. The previous `|| echo` made exactly that green.
+          src="data/v1.2/baseline_results/${{ matrix.baseline }}_${{ inputs.split || 'dev_public' }}.json"
+          if [ ! -f "$src" ]; then
+            echo "::error::no pre-computed result at $src -- this leg has nothing to evaluate"
+            exit 1
+          fi
+          cp "$src" results/
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # needed for hatch-vcs
+          # The raw-versus-aggregate guard (tests/test_released_raw_matches_its_aggregate.py)
+          # skips on an unfetched LFS pointer, and without this it skipped in every
+          # CI run -- run 33948126186 shows `s.` on all four Python versions -- so the
+          # guard that #54 added was inert exactly where it was meant to run.
+          lfs: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/hallmark/evaluation/validate.py
+++ b/hallmark/evaluation/validate.py
@@ -155,6 +155,25 @@ def validate_reference_results(
                         f"doesn't match metadata total={expected_total} "
                         f"for split {split_name}"
                     )
+                # A count short by exactly the canaries is only fine if the
+                # canaries are what is missing. The canary is the split's only
+                # VALID entry, so a short result that still reports a VALID
+                # entry dropped a hallucinated one instead -- which the count
+                # allowance alone cannot see, and which made it a one-entry
+                # tolerance in practice.
+                canaries = CANARY_ENTRIES.get(split_name, 0)
+                if (
+                    expected_total is not None
+                    and canaries
+                    and result.num_entries == expected_total - canaries
+                    and result.num_valid != 0
+                ):
+                    errors.append(
+                        f"{filename}: num_entries={result.num_entries} omits {canaries} "
+                        f"entry(ies) from split {split_name} but num_valid="
+                        f"{result.num_valid}; the omitted entry is not the VALID canary, "
+                        "so a scored entry was dropped"
+                    )
 
         # Strict: reject F1=0.0 as likely failed run
         if strict and result.f1_hallucination == 0.0:

--- a/tests/test_stress_canary_is_not_a_missing_entry.py
+++ b/tests/test_stress_canary_is_not_a_missing_entry.py
@@ -15,7 +15,15 @@ check exists to catch.
 
 from __future__ import annotations
 
-from hallmark.evaluation.validate import CANARY_ENTRIES, _allowed_entry_counts
+import json
+
+from hallmark.dataset.schema import EvaluationResult
+from hallmark.evaluation.validate import (
+    CANARY_ENTRIES,
+    _allowed_entry_counts,
+    compute_sha256,
+    validate_reference_results,
+)
 
 
 def test_stress_test_may_omit_its_canary():
@@ -40,3 +48,55 @@ def test_unknown_total_permits_nothing():
 def test_only_stress_test_is_registered():
     """Pins the scope. A second entry here needs its own justification."""
     assert CANARY_ENTRIES == {"stress_test": 1}
+
+
+# --- The omitted entry must be the canary ------------------------------------------
+
+
+def _stress_result(tmp_path, *, num_entries: int, num_valid: int):
+    result = EvaluationResult(
+        tool_name="cascade_db_diagnosis",
+        split_name="stress_test",
+        num_entries=num_entries,
+        num_hallucinated=num_entries - num_valid,
+        num_valid=num_valid,
+        detection_rate=0.9,
+        false_positive_rate=None,
+        f1_hallucination=0.9,
+        tier_weighted_f1=0.9,
+    )
+    filename = "cascade_db_diagnosis_stress_test.json"
+    path = tmp_path / filename
+    path.write_text(result.to_json())
+    manifest = {
+        "version": "1.0",
+        "files": {
+            filename: {"sha256": compute_sha256(path), "baseline": "x", "split": "stress_test"}
+        },
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    meta = tmp_path / "metadata.json"
+    meta.write_text(json.dumps({"splits": {"stress_test": {"total": 122}}}))
+    return validate_reference_results(tmp_path, metadata_path=meta)
+
+
+def test_omitting_the_canary_passes(tmp_path):
+    """121 scored, none of them VALID: the one missing entry is the canary."""
+    vr = _stress_result(tmp_path, num_entries=121, num_valid=0)
+    assert vr.passed, vr.errors
+
+
+def test_omitting_a_hallucinated_entry_instead_fails(tmp_path):
+    """121 scored but the VALID canary is among them: a real entry was dropped.
+
+    The count allowance alone cannot tell these apart, which made it a
+    one-entry tolerance in practice.
+    """
+    vr = _stress_result(tmp_path, num_entries=121, num_valid=1)
+    assert not vr.passed
+    assert any("canary" in e for e in vr.errors), vr.errors
+
+
+def test_the_full_split_with_its_canary_passes(tmp_path):
+    vr = _stress_result(tmp_path, num_entries=122, num_valid=1)
+    assert vr.passed, vr.errors


### PR DESCRIPTION
Three CI/validator items from the critical pass over #36–#55, one commit each.

## The canary exemption was a one-entry tolerance

`_allowed_entry_counts` (#53) accepts 121 for any tool on `stress_test` without asking which entry is missing. The canary is the split's only VALID entry, so a result that is short by one **and still reports `num_valid == 1`** dropped a hallucinated entry, which is the failure the check exists to catch. The validator now fails that case with a message naming the canary; the three released cascade files report `num_valid 0` and pass unchanged. `validate-results --strict --metadata` on the released directory: passed.

## The #54 guard never ran in CI

`tests/test_released_raw_matches_its_aggregate.py` skips on an unfetched LFS pointer, and no workflow checked out with `lfs: true`. Run 33948126186 shows `s.` for that module on all four Python versions. The tests job now fetches LFS objects; the cost is about 300 KB per run.

## The HaRC leg of `baselines.yml` reported success having copied nothing

It copied `harc_dev_public.json`, withdrawn on 2026-09-04 as a truncated run. `cp … || echo` swallowed the failure and `if-no-files-found: warn` shrugged at the empty artifact, so run 33948051695 shows the job green with the warning `No files were found with the provided path: results/harc_dev_public.json`. The #50 gate reads job conclusions and cannot see a step that was told to swallow its own failure. A missing precomputed result is now an error, and harc leaves the matrix until it has a current result (the keyed run is registered known-stale), since a leg that fails every Monday by design would turn the gate back into noise.

Tests: the new identity case fails on `main` and passes here; validate and freshness selections green; ruff and mypy clean; the workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp