### PR TITLE
The released artifacts contradict themselves in three places

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ them as negatives so flagging one is a false accusation:
 
 | split | folded out of the scored set | scored as false positives |
 |---|---|---|
-| `test_public` | Kendall tau 0.886, 14 of 21 tools change rank | tau 0.829, 17 of 21 change |
-| `dev_public` | tau 0.905, 15 of 20 change | tau 0.811, 17 of 20 change |
+| `test_public` | Kendall tau 0.884, 13 of 20 tools change rank | tau 0.821, 16 of 20 change |
+| `dev_public` | tau 0.906, 14 of 19 change | tau 0.801, 16 of 19 change |
 
 The top of the table changes identity: `cascade_db_diagnosis` leads as shipped at
 MCC 0.897 on `test_public`, and `bibtexupdater` takes first place under
@@ -258,11 +258,17 @@ How much of a tool's credit comes from these modes varies widely, and no
 published column shows it. On `test_public` they are 27.0% of the cascade's 514
 detections, 23.2% of Sonnet 4.6's, 20.0% of `bibtexupdater`'s and 9.1% of
 `doi_only`'s. Detection rate on the four ranges from 0.065 (`doi_only`) to 1.000
-(the cascade), median 0.755 across 21 tools.
+(the cascade), median 0.740 across 20 tools. The counts exclude one
+byte-identical duplicate result file per split (`cascade_db_diagnosis_evalmode_aggressive_*`
+is a copy of `cascade_db_diagnosis_aggressive_*`) and, on `dev_public`, the Opus 4.7
+result, whose per-type block predates the relabel and does not reproduce its
+published MCC; it is registered known-stale in `scripts/check_results_freshness.py`.
 
-Two controls bound what this means. Folding `hybrid_fabrication` alone moves
-nothing — tau 1.000 with no tool changing position on either public split — so
-the instability belongs to the four modes rather than to folding a mode class,
+Two controls bound what this means. Folding `hybrid_fabrication` alone leaves
+the folded-out ranking unchanged on both public splits — tau 1.000, no tool
+changing position — and moves six tools under as-false-positives (tau 0.968 and
+0.965), so the instability belongs to the four modes rather than to folding a
+mode class,
 though at 4.3% and 5.6% of positives that null carries less weight than the
 effect it contrasts with. And the cascade's 1.000 is not an artefact of how the
 entries were generated: a gradient-boosted classifier over surface features
@@ -271,9 +277,9 @@ and 0.388 on `test_public` against false-positive rates of 0.045 and 0.096. Some
 separability is there, and it is far short of what the cascade achieves.
 
 `stress_test` inherits the same property by construction. It holds three modes,
-two of which are on this list: 75 of its 121 scored entries, 62%. It carries no
-VALID entries, so its false-positive rate is undefined and its MCC is 0.0 by
-degeneracy rather than by measurement, and every one of the cascade's misses
+two of which are on this list: 75 of its 121 scored entries, 62%. Its one VALID
+entry is a contamination canary excluded from scoring, so its false-positive
+rate is undefined and its MCC is 0.0 by degeneracy rather than by measurement, and every one of the cascade's misses
 there is on the two real-paper modes — folding them takes it from 0.953 to 1.000.
 
 **No labels change in this release.** Separating the two questions means

--- a/data/v1.2/baseline_results/bibtexupdater_dev_public.json
+++ b/data/v1.2/baseline_results/bibtexupdater_dev_public.json
@@ -145,7 +145,7 @@
     }
   },
   "coverage": 0.8624,
-  "coverage_adjusted_f1": 0.8903993203058623,
+  "coverage_adjusted_f1": 0.7678803738317758,
   "type_accuracy": {
     "overall": NaN,
     "main_types_only": NaN,
@@ -484,7 +484,7 @@
     "splits": [
       "dev_public"
     ],
-    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/dev_public/btu_raw.jsonl under ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports. See scripts/rescore_btu_from_raw.py."
+    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/dev_public/btu_raw.jsonl under ABSTENTION_STATUSES, and coverage_adjusted_f1 recomputed as f1_hallucination x coverage per its definition in metrics.py. The DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports; under that convention coverage_adjusted_f1 counts abstention twice (once as a committed miss inside F1, once through coverage) and is a lower bound, not a third scoring. See scripts/rescore_btu_from_raw.py."
   },
   "_btu_status_histogram": {
     "arxiv_id_mismatch": 18,

--- a/data/v1.2/baseline_results/bibtexupdater_test_public.json
+++ b/data/v1.2/baseline_results/bibtexupdater_test_public.json
@@ -145,7 +145,7 @@
     }
   },
   "coverage": 0.8761,
-  "coverage_adjusted_f1": 0.900990099009901,
+  "coverage_adjusted_f1": 0.7893574257425743,
   "type_accuracy": {
     "overall": NaN,
     "main_types_only": NaN,
@@ -484,7 +484,7 @@
     "splits": [
       "test_public"
     ],
-    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/test_public/btu_raw.jsonl under ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports. See scripts/rescore_btu_from_raw.py."
+    "coverage_corrected": "coverage and num_uncertain recounted from results/relabel_delta/btu_v1_2_0/test_public/btu_raw.jsonl under ABSTENTION_STATUSES, and coverage_adjusted_f1 recomputed as f1_hallucination x coverage per its definition in metrics.py. The DR/FPR/F1 triple is unchanged and still scores abstentions as committed-VALID, which is the convention the paper reports; under that convention coverage_adjusted_f1 counts abstention twice (once as a committed miss inside F1, once through coverage) and is a lower bound, not a third scoring. See scripts/rescore_btu_from_raw.py."
   },
   "_btu_status_histogram": {
     "arxiv_id_mismatch": 14,

--- a/data/v1.2/baseline_results/manifest.json
+++ b/data/v1.2/baseline_results/manifest.json
@@ -2,14 +2,14 @@
   "version": "1.0",
   "files": {
     "bibtexupdater_dev_public.json": {
-      "sha256": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
+      "sha256": "ffd86c74d466d1477cf358d571f02c9ed4c4df6dc7df605ad8b8a7a596dbba39",
       "baseline": "bibtexupdater",
       "split": "dev_public",
       "num_entries": 1119,
       "f1_hallucination": 0.8903993203058623
     },
     "bibtexupdater_test_public.json": {
-      "sha256": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
+      "sha256": "132b4d2fa383b8c2f359bb62e5c9ce6ab1f3f14ce233b88edb25293d9870e517",
       "baseline": "bibtexupdater",
       "split": "test_public",
       "num_entries": 831,

--- a/scripts/ablate_taxonomy_fold.py
+++ b/scripts/ablate_taxonomy_fold.py
@@ -38,8 +38,10 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import math
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -178,6 +180,11 @@ def _reconstruction_error(payload: dict, shipped: Confusion) -> list[str]:
     return problems
 
 
+def _rel(path: Path) -> str:
+    """Repo-relative when inside the repo, else as given (tests write to tmp)."""
+    return os.path.relpath(path, REPO_ROOT) if path.is_relative_to(REPO_ROOT) else str(path)
+
+
 def _kendall_tau(a: list[str], b: list[str]) -> float:
     """Rank correlation between two orderings of the same tools."""
     pos_a = {name: i for i, name in enumerate(a)}
@@ -225,8 +232,17 @@ def main() -> int:
     real_mode_drs: dict[str, float] = {}
     dropped: dict[str, str] = {}
     used_inputs: list[Path] = []
+    # One result under two names is one tool. cascade_db_diagnosis_aggressive_*
+    # and cascade_db_diagnosis_evalmode_aggressive_* are byte-identical on every
+    # split; scored twice they inflated every "N of M tools" count.
+    seen_digests: dict[str, str] = {}
 
     for path in results:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if digest in seen_digests:
+            dropped[path.stem] = f"byte-identical to {seen_digests[digest]}"
+            continue
+        seen_digests[digest] = path.stem
         try:
             payload = json.loads(path.read_text())
         except (OSError, json.JSONDecodeError) as exc:
@@ -316,7 +332,7 @@ def main() -> int:
         )
 
     if not has_negatives:
-        print(f"\nWrote {args.output.relative_to(REPO_ROOT)}")
+        print(f"\nWrote {_rel(args.output)}")
         return 0
 
     print("\nRanking agreement with as_shipped (Kendall tau over MCC):")
@@ -330,7 +346,7 @@ def main() -> int:
         print(f"  {scoring:<20} tau={tau:+.4f}  tools changing position: {moved}/{len(scored)}")
         print(f"    top 5: {', '.join(order[scoring][:5])}")
 
-    print(f"\nWrote {args.output.relative_to(REPO_ROOT)}")
+    print(f"\nWrote {_rel(args.output)}")
     return 0
 
 

--- a/scripts/check_results_freshness.py
+++ b/scripts/check_results_freshness.py
@@ -77,6 +77,19 @@ DEFAULT_TABLES_DIR = Path("tables")
 #: Ratchet DOWN only: a name leaves this dict when the result is regenerated, and
 #: adding one is a decision to ship a number scored against data that has moved.
 KNOWN_STALE: dict[str, str] = {
+    "llm_openrouter_claude_opus_4_7_dev_public.json": (
+        "per-type counts sum to 633 positives (the pre-relabel dev_public) while the "
+        "headline counts say 606 / 513: the top-level counts were patched, the per-type "
+        "block was not, so the per-type figures describe a different split. The "
+        "taxonomy-fold ablation drops this file because its rebuilt MCC (0.6625) does "
+        "not reproduce the published 0.6828. Needs a re-run under the current labels."
+    ),
+    "llm_openrouter_claude_sonnet_4_6_dev_public.json": (
+        "per-type counts sum to 633 positives (the pre-relabel dev_public) while the "
+        "headline counts say 606 / 513, as for the Opus 4.7 file above. Its rebuilt MCC "
+        "happens to land within the ablation's 0.02 tolerance, so it was scored there "
+        "as if current. Needs a re-run under the current labels."
+    ),
     "harc_with_s2key_dev_public.json": (
         "scored against the pre-relabel ground truth (633 hallucinated / 486 valid "
         "against the current 606 / 513). Full coverage at n=1,119, but its DR 0.209 "
@@ -261,6 +274,27 @@ def check_freshness(
                 report.is_stale = True
                 report.reasons.append(
                     f"{key} mismatch: recorded {recorded} != current split {expected}"
+                )
+
+        # (3) per-type check: the per-type counts must sum to the split's positives.
+        #
+        # The headline counts can be patched without the per-type block being
+        # regenerated, and then (2) passes a result whose per-type figures
+        # describe a different split. Two released dev_public results carried
+        # per-type counts summing to 633 (the pre-relabel split) under headline
+        # counts of 606 / 513, and the fold ablation scored one of them.
+        per_type = probe.get("per_type_metrics")
+        if isinstance(per_type, dict) and per_type:
+            per_type_positives = sum(
+                int(m.get("count") or 0)
+                for mode, m in per_type.items()
+                if mode != "valid" and isinstance(m, dict)
+            )
+            if per_type_positives != current["num_hallucinated"]:
+                report.is_stale = True
+                report.reasons.append(
+                    f"per_type_metrics counts sum to {per_type_positives} positives != "
+                    f"current split {current['num_hallucinated']}"
                 )
 
         reports.append(report)

--- a/scripts/rescore_btu_from_raw.py
+++ b/scripts/rescore_btu_from_raw.py
@@ -7,7 +7,10 @@ abstentions. The wrapper wrote every abstention as a committed VALID, so the
 field that was supposed to record them recorded nothing. The paper's Coverage
 column says otherwise, and the artifact a reader can recompute was the wrong one.
 
-**Only those two fields change.** The DR/FPR/F1 triple stays exactly as released,
+**Only those two fields and the one derived from them change.**
+``coverage_adjusted_f1`` is ``f1_hallucination * coverage`` by definition
+(``metrics.py``) and moves with coverage; left at ``f1 * 1.0`` it contradicted
+the file's own coverage. The DR/FPR/F1 triple stays exactly as released,
 which is the paper's documented convention: abstentions score as committed-VALID
 in the triple, and Coverage reports the fraction the tool committed to. Two
 reasons not to re-score the triple here:
@@ -92,8 +95,10 @@ def main() -> int:
     coverage = answered / len(entries)
 
     print(f"{args.split}: {len(entries)} entries, {len(predictions)} records")
+    cov_adj_f1 = released["f1_hallucination"] * coverage
     print(f"  coverage        {released['coverage']}  ->  {coverage:.4f}")
     print(f"  num_uncertain   {released['num_uncertain']}  ->  {abstentions}")
+    print(f"  cov-adjusted F1 {released['coverage_adjusted_f1']:.4f}  ->  {cov_adj_f1:.4f}")
     print("  DR/FPR/F1       unchanged (committed-VALID convention, as released)")
 
     if not args.apply:
@@ -102,11 +107,15 @@ def main() -> int:
 
     released["coverage"] = round(coverage, 4)
     released["num_uncertain"] = abstentions
+    released["coverage_adjusted_f1"] = released["f1_hallucination"] * released["coverage"]
     released.setdefault("_provenance", {})["coverage_corrected"] = (
         f"coverage and num_uncertain recounted from {args.raw.as_posix()} under "
-        "ABSTENTION_STATUSES; the DR/FPR/F1 triple is unchanged and still scores "
-        "abstentions as committed-VALID, which is the convention the paper reports. "
-        "See scripts/rescore_btu_from_raw.py."
+        "ABSTENTION_STATUSES, and coverage_adjusted_f1 recomputed as f1_hallucination x "
+        "coverage per its definition in metrics.py. The DR/FPR/F1 triple is unchanged "
+        "and still scores abstentions as committed-VALID, which is the convention the "
+        "paper reports; under that convention coverage_adjusted_f1 counts abstention "
+        "twice (once as a committed miss inside F1, once through coverage) and is a "
+        "lower bound, not a third scoring. See scripts/rescore_btu_from_raw.py."
     )
     target.write_text(json.dumps(released, indent=2, ensure_ascii=False) + "\n")
     print(f"\nwrote {target}")

--- a/tables/provenance.json
+++ b/tables/provenance.json
@@ -2,7 +2,7 @@
   "base_rate_precision.csv": {
     "generator": "scripts/compute_base_rate_precision.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "132b4d2fa383b8c2f359bb62e5c9ce6ab1f3f14ce233b88edb25293d9870e517",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",
@@ -28,10 +28,9 @@
   "taxonomy_fold_ablation_dev_public.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
+      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "ffd86c74d466d1477cf358d571f02c9ed4c4df6dc7df605ad8b8a7a596dbba39",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/cascade_db_diagnosis_dev_public.json": "5df803dde0d7fe80413072132677630b09761e9d313370611712ae0a7851747c",
-      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/doi_only_dev_public.json": "6580622f7c22e40bf24bf660c4cb375b2e1d3ec45bff716c2cbc1e9f1504397e",
       "data/v1.2/baseline_results/harc_with_s2key_dev_public.json": "79d7a33050e82e3609a1418641c189bcfe98c5c06b3f14270c9a08d62c4968a6",
       "data/v1.2/baseline_results/llm_agentic_btu_openai_dev_public.json": "c3545fea4b9bb6001146fa135e15989781e4fe757b08689a8eb11a2dc82ad407",
@@ -53,10 +52,9 @@
   "taxonomy_fold_ablation_dev_public_hybrid_fabrication.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "09778d2a41631733c3ab9c42cc612754efbe0dd32c957896463db7179bde0715",
+      "data/v1.2/baseline_results/bibtexupdater_dev_public.json": "ffd86c74d466d1477cf358d571f02c9ed4c4df6dc7df605ad8b8a7a596dbba39",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/cascade_db_diagnosis_dev_public.json": "5df803dde0d7fe80413072132677630b09761e9d313370611712ae0a7851747c",
-      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_dev_public.json": "0f54d388799fbf499937679ba7e8b779d2fe8e3b05646e7f3933b966b16f3a3a",
       "data/v1.2/baseline_results/doi_only_dev_public.json": "6580622f7c22e40bf24bf660c4cb375b2e1d3ec45bff716c2cbc1e9f1504397e",
       "data/v1.2/baseline_results/harc_with_s2key_dev_public.json": "79d7a33050e82e3609a1418641c189bcfe98c5c06b3f14270c9a08d62c4968a6",
       "data/v1.2/baseline_results/llm_agentic_btu_openai_dev_public.json": "c3545fea4b9bb6001146fa135e15989781e4fe757b08689a8eb11a2dc82ad407",
@@ -79,16 +77,14 @@
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_stress_test.json": "8e12d13b07e0dd37a8ce0bc9bd1dfe09b8075df0f957a32567be4f527290a4ed",
-      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_stress_test.json": "8e12d13b07e0dd37a8ce0bc9bd1dfe09b8075df0f957a32567be4f527290a4ed",
       "data/v1.2/baseline_results/cascade_db_diagnosis_stress_test.json": "623222b43e505060ddd7fcf5c209c7961f77395bccc177d0fc09f41f5adfa21c"
     }
   },
   "taxonomy_fold_ablation_test_public.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "132b4d2fa383b8c2f359bb62e5c9ce6ab1f3f14ce233b88edb25293d9870e517",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
-      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",
       "data/v1.2/baseline_results/doi_only_test_public.json": "716ed587dc829f3b549ad5e846310a4705626758c80b432e42218d4aad274fda",
       "data/v1.2/baseline_results/llm_agentic_btu_openai_test_public.json": "f8001545cd20f90ea06bd9a13590c74d5e32491a0a573c59fa249de2edc92f20",
@@ -112,9 +108,8 @@
   "taxonomy_fold_ablation_test_public_hybrid_fabrication.csv": {
     "generator": "scripts/ablate_taxonomy_fold.py",
     "inputs": {
-      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "d31eca7871bc1b6f2f0f13e734f7478f0ae00dcf45b879aaf2679075c484d9cc",
+      "data/v1.2/baseline_results/bibtexupdater_test_public.json": "132b4d2fa383b8c2f359bb62e5c9ce6ab1f3f14ce233b88edb25293d9870e517",
       "data/v1.2/baseline_results/cascade_db_diagnosis_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
-      "data/v1.2/baseline_results/cascade_db_diagnosis_evalmode_aggressive_test_public.json": "f8c2b0cdc4a311a741c9528880de28fea8759cd3dd4bfd1ca715851c3f2595c5",
       "data/v1.2/baseline_results/cascade_db_diagnosis_test_public.json": "0b8e28af6ceaa9b327d17bea79a9fd5c7d59d596c7eff966dfcd076485241d77",
       "data/v1.2/baseline_results/doi_only_test_public.json": "716ed587dc829f3b549ad5e846310a4705626758c80b432e42218d4aad274fda",
       "data/v1.2/baseline_results/llm_agentic_btu_openai_test_public.json": "f8001545cd20f90ea06bd9a13590c74d5e32491a0a573c59fa249de2edc92f20",

--- a/tables/taxonomy_fold_ablation_dev_public.csv
+++ b/tables/taxonomy_fold_ablation_dev_public.csv
@@ -2,7 +2,6 @@ tool,split,real_mode_dr,as_shipped_dr,as_shipped_fpr,as_shipped_f1,as_shipped_mc
 bibtexupdater_dev_public,dev_public,0.5975,0.8647,0.0916,0.8904,0.7706,0.9597,0.0916,0.9296,0.8661,0.9597,0.2113,0.8428,0.7333
 cascade_db_diagnosis_aggressive_dev_public,dev_public,0.9937,0.9967,0.1481,0.9393,0.8659,0.9978,0.1481,0.9205,0.8509,0.9978,0.3482,0.7915,0.6516
 cascade_db_diagnosis_dev_public,dev_public,0.9894,0.9951,0.1072,0.9542,0.8989,0.9972,0.1072,0.9406,0.8887,0.9972,0.3159,0.8067,0.6779
-cascade_db_diagnosis_evalmode_aggressive_dev_public,dev_public,0.9937,0.9967,0.1481,0.9393,0.8659,0.9978,0.1481,0.9205,0.8509,0.9978,0.3482,0.7915,0.6516
 doi_only_dev_public,dev_public,0.1203,0.2178,0.0429,0.3474,0.2530,0.2522,0.0429,0.3877,0.3005,0.2522,0.0611,0.3754,0.2718
 harc_with_s2key_dev_public,dev_public,0.1314,0.2085,0.0453,0.3355,0.2349,0.2298,0.0453,0.3608,0.2672,0.2298,0.0642,0.3508,0.2388
 llm_agentic_btu_openai_dev_public,dev_public,0.9686,0.9802,0.4698,0.8244,0.5844,0.9843,0.4698,0.7801,0.5653,0.9843,0.5878,0.6864,0.4463

--- a/tables/taxonomy_fold_ablation_dev_public_hybrid_fabrication.csv
+++ b/tables/taxonomy_fold_ablation_dev_public_hybrid_fabrication.csv
@@ -2,7 +2,6 @@ tool,split,real_mode_dr,as_shipped_dr,as_shipped_fpr,as_shipped_f1,as_shipped_mc
 bibtexupdater_dev_public,dev_public,1.0000,0.8647,0.0916,0.8904,0.7706,0.8586,0.0916,0.8853,0.7656,0.8586,0.1354,0.8653,0.7229
 cascade_db_diagnosis_aggressive_dev_public,dev_public,1.0000,0.9967,0.1481,0.9393,0.8659,0.9966,0.1481,0.9368,0.8637,0.9966,0.1892,0.9175,0.8262
 cascade_db_diagnosis_dev_public,dev_public,1.0000,0.9951,0.1072,0.9542,0.8989,0.9949,0.1072,0.9522,0.8971,0.9949,0.1503,0.9322,0.8575
-cascade_db_diagnosis_evalmode_aggressive_dev_public,dev_public,1.0000,0.9967,0.1481,0.9393,0.8659,0.9966,0.1481,0.9368,0.8637,0.9966,0.1892,0.9175,0.8262
 doi_only_dev_public,dev_public,0.1538,0.2178,0.0429,0.3474,0.2530,0.2207,0.0429,0.3507,0.2579,0.2207,0.0482,0.3488,0.2501
 harc_with_s2key_dev_public,dev_public,0.0889,0.2085,0.0453,0.3355,0.2349,0.2177,0.0453,0.3469,0.2476,0.2177,0.0490,0.3450,0.2446
 llm_agentic_btu_openai_dev_public,dev_public,1.0000,0.9802,0.4698,0.8244,0.5844,0.9793,0.4698,0.8179,0.5798,0.9793,0.4954,0.8028,0.5557

--- a/tables/taxonomy_fold_ablation_stress_test.csv
+++ b/tables/taxonomy_fold_ablation_stress_test.csv
@@ -1,4 +1,3 @@
 tool,split,real_mode_dr,as_shipped_dr,as_shipped_fpr,as_shipped_f1,as_shipped_mcc,folded_out_dr,folded_out_fpr,folded_out_f1,folded_out_mcc,as_false_positives_dr,as_false_positives_fpr,as_false_positives_f1,as_false_positives_mcc
 cascade_db_diagnosis_aggressive_stress_test,stress_test,0.9333,0.9587,0.0000,0.9789,0.0000,1.0000,0.0000,1.0000,0.0000,1.0000,0.9333,0.5679,0.1626
-cascade_db_diagnosis_evalmode_aggressive_stress_test,stress_test,0.9333,0.9587,0.0000,0.9789,0.0000,1.0000,0.0000,1.0000,0.0000,1.0000,0.9333,0.5679,0.1626
 cascade_db_diagnosis_stress_test,stress_test,0.9242,0.9530,0.0000,0.9759,0.0000,1.0000,0.0000,1.0000,0.0000,1.0000,0.9242,0.5703,0.1739

--- a/tables/taxonomy_fold_ablation_test_public.csv
+++ b/tables/taxonomy_fold_ablation_test_public.csv
@@ -1,7 +1,6 @@
 tool,split,real_mode_dr,as_shipped_dr,as_shipped_fpr,as_shipped_f1,as_shipped_mcc,folded_out_dr,folded_out_fpr,folded_out_f1,folded_out_mcc,as_false_positives_dr,as_false_positives_fpr,as_false_positives_f1,as_false_positives_mcc
 bibtexupdater_test_public,test_public,0.6547,0.8767,0.1154,0.9010,0.7498,0.9579,0.1154,0.9333,0.8488,0.9579,0.2816,0.8358,0.6852
 cascade_db_diagnosis_aggressive_test_public,test_public,1.0000,0.9923,0.1603,0.9502,0.8637,0.9895,0.1603,0.9330,0.8482,0.9895,0.4191,0.7958,0.6091
-cascade_db_diagnosis_evalmode_aggressive_test_public,test_public,1.0000,0.9923,0.1603,0.9502,0.8637,0.9895,0.1603,0.9330,0.8482,0.9895,0.4191,0.7958,0.6091
 cascade_db_diagnosis_test_public,test_public,1.0000,0.9897,0.1122,0.9622,0.8972,0.9860,0.1122,0.9489,0.8847,0.9860,0.3858,0.8069,0.6313
 doi_only_test_public,test_public,0.0647,0.1908,0.0417,0.3138,0.2114,0.2368,0.0417,0.3727,0.2728,0.2368,0.0488,0.3659,0.2744
 llm_agentic_btu_openai_test_public,test_public,0.9209,0.9595,0.3558,0.8830,0.6608,0.9737,0.3558,0.8595,0.6679,0.9737,0.5299,0.7482,0.4996

--- a/tables/taxonomy_fold_ablation_test_public_hybrid_fabrication.csv
+++ b/tables/taxonomy_fold_ablation_test_public_hybrid_fabrication.csv
@@ -1,7 +1,6 @@
 tool,split,real_mode_dr,as_shipped_dr,as_shipped_fpr,as_shipped_f1,as_shipped_mcc,folded_out_dr,folded_out_fpr,folded_out_f1,folded_out_mcc,as_false_positives_dr,as_false_positives_fpr,as_false_positives_f1,as_false_positives_mcc
 bibtexupdater_test_public,test_public,1.0000,0.8767,0.1154,0.9010,0.7498,0.8694,0.1154,0.8950,0.7439,0.8694,0.1906,0.8685,0.6791
 cascade_db_diagnosis_aggressive_test_public,test_public,1.0000,0.9923,0.1603,0.9502,0.8637,0.9918,0.1603,0.9474,0.8611,0.9918,0.2317,0.9213,0.8015
-cascade_db_diagnosis_evalmode_aggressive_test_public,test_public,1.0000,0.9923,0.1603,0.9502,0.8637,0.9918,0.1603,0.9474,0.8611,0.9918,0.2317,0.9213,0.8015
 cascade_db_diagnosis_test_public,test_public,1.0000,0.9897,0.1122,0.9622,0.8972,0.9891,0.1122,0.9601,0.8952,0.9891,0.1877,0.9332,0.8324
 doi_only_test_public,test_public,0.1034,0.1908,0.0417,0.3138,0.2114,0.1959,0.0417,0.3205,0.2194,0.1959,0.0469,0.3189,0.2146
 llm_agentic_btu_openai_test_public,test_public,1.0000,0.9595,0.3558,0.8830,0.6608,0.9571,0.3558,0.8766,0.6553,0.9571,0.4106,0.8535,0.6076

--- a/tests/test_ablation_drops_byte_identical_inputs.py
+++ b/tests/test_ablation_drops_byte_identical_inputs.py
@@ -1,0 +1,75 @@
+"""The taxonomy-fold ablation must not count one result twice.
+
+``cascade_db_diagnosis_aggressive_*`` and ``cascade_db_diagnosis_evalmode_aggressive_*``
+are byte-identical on all three splits, with ``tool_name`` ``cascade_db_diagnosis``
+inside both. Scored as two tools they inflated the README's "21 of 21" and
+"20 of 20" counts and every rank-move figure derived from them.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import ablate_taxonomy_fold as fold  # noqa: E402
+
+
+def _payload() -> dict:
+    """A result whose published figures the script's reconstruction reproduces."""
+    per_type = {
+        "fabricated_doi": {"count": 10, "detection_rate": 0.8},
+        "wrong_venue": {"count": 5, "detection_rate": 1.0},
+        "valid": {"count": 10},
+    }
+    tp = 10 * 0.8 + 5 * 1.0
+    fn = 15 - tp
+    cm = fold.Confusion(tp=tp, fp=1.0, fn=fn, tn=9.0)
+    return {
+        "tool_name": "tool",
+        "split_name": "test_public",
+        "num_entries": 25,
+        "num_hallucinated": 15,
+        "num_valid": 10,
+        "detection_rate": cm.detection_rate,
+        "false_positive_rate": cm.false_positive_rate,
+        "f1_hallucination": cm.f1,
+        "mcc": cm.mcc,
+        "per_type_metrics": per_type,
+    }
+
+
+def test_a_byte_identical_copy_is_dropped_and_named(tmp_path, capsys, monkeypatch):
+    results = tmp_path / "results"
+    results.mkdir()
+    text = json.dumps(_payload(), indent=2)
+    (results / "a_tool_test_public.json").write_text(text)
+    (results / "a_tool_z_copy_test_public.json").write_text(text)
+    other = _payload()
+    other["per_type_metrics"]["fabricated_doi"]["detection_rate"] = 0.5
+    cm = fold.Confusion(tp=10 * 0.5 + 5.0, fp=1.0, fn=15 - (10 * 0.5 + 5.0), tn=9.0)
+    other.update(
+        detection_rate=cm.detection_rate,
+        false_positive_rate=cm.false_positive_rate,
+        f1_hallucination=cm.f1,
+        mcc=cm.mcc,
+    )
+    (results / "b_tool_test_public.json").write_text(json.dumps(other))
+
+    out = tmp_path / "fold.csv"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ablate", "--split", "test_public", "--results-dir", str(results), "--output", str(out)],
+    )
+    assert fold.main() == 0
+
+    rows = list(csv.DictReader(out.open()))
+    assert [r["tool"] for r in rows] == ["a_tool_test_public", "b_tool_test_public"]
+    printed = capsys.readouterr().out
+    assert "a_tool_z_copy_test_public" in printed and "byte-identical" in printed

--- a/tests/test_released_results_record_their_abstentions.py
+++ b/tests/test_released_results_record_their_abstentions.py
@@ -78,3 +78,25 @@ def test_the_triple_still_uses_the_committed_convention():
     assert result["detection_rate"] == pytest.approx(0.8647, abs=5e-4)
     assert result["false_positive_rate"] == pytest.approx(0.0916, abs=5e-4)
     assert result["f1_hallucination"] == pytest.approx(0.8904, abs=5e-4)
+
+
+@pytest.mark.parametrize("split", sorted(EXPECTED_ABSTENTIONS))
+def test_coverage_adjusted_f1_matches_its_definition(split: str):
+    """``coverage_adjusted_f1`` is ``f1_hallucination * coverage`` (metrics.py).
+
+    The coverage correction rewrote ``coverage`` and left this field at the old
+    ``f1 * 1.0``, so the file contradicted its own definition and the leaderboard
+    showed bibtex-updater un-penalised on the one column whose purpose is to
+    penalise abstention. Under the committed-VALID triple this double-counts
+    abstention; that is documented in the provenance string, not hidden in the
+    number.
+    """
+    path = RESULTS / f"bibtexupdater_{split}.json"
+    if not path.is_file():
+        pytest.skip(f"{path.name} not present")
+    result = json.loads(path.read_text())
+    expected = result["f1_hallucination"] * result["coverage"]
+    assert result["coverage_adjusted_f1"] == pytest.approx(expected, abs=5e-4), (
+        f"{path.name}: coverage_adjusted_f1 {result['coverage_adjusted_f1']:.4f} but "
+        f"f1 {result['f1_hallucination']:.4f} x coverage {result['coverage']} = {expected:.4f}"
+    )

--- a/tests/test_results_freshness.py
+++ b/tests/test_results_freshness.py
@@ -342,3 +342,66 @@ def test_known_stale_register_only_shrinks():
     assert not obsolete, (
         f"listed in KNOWN_STALE but no longer stale: {obsolete}. Remove them from the register."
     )
+
+
+# --- Tests: stale by per-type counts ------------------------------------------
+
+
+def test_stale_when_per_type_counts_sum_past_the_split(tmp_path):
+    """Per-type counts that sum to more positives than the split has are a
+    different run's per-type block under patched headline counts.
+
+    Two released dev_public results carry per-type counts summing to 633 (the
+    pre-relabel split) while declaring num_hallucinated 606. The headline
+    counts were patched; the per-type block was not; the count check saw the
+    patched numbers and passed them.
+    """
+    data_dir, _split_file, results_dir = _build_env(tmp_path, n_hall=10, n_valid=10)
+    result_file = results_dir / "mytool_dev_public.json"
+    _write_result(
+        result_file, tool="mytool", split="dev_public", n_entries=20, n_hall=10, n_valid=10
+    )
+    payload = json.loads(result_file.read_text())
+    payload["per_type_metrics"] = {
+        "fabricated_doi": {"count": 8, "detection_rate": 0.5},
+        "wrong_venue": {"count": 4, "detection_rate": 0.5},
+        "valid": {"count": 10},
+    }
+    result_file.write_text(json.dumps(payload))
+
+    res = crf.check_freshness(results_dir, version="v1.2", data_dir=data_dir)
+    assert res.stale_files == ["mytool_dev_public.json"]
+    assert any("per_type" in r for r in res.reports[0].reasons), res.reports[0].reasons
+
+
+def test_per_type_counts_that_match_are_fresh(tmp_path):
+    data_dir, _split_file, results_dir = _build_env(tmp_path, n_hall=10, n_valid=10)
+    result_file = results_dir / "mytool_dev_public.json"
+    _write_result(
+        result_file, tool="mytool", split="dev_public", n_entries=20, n_hall=10, n_valid=10
+    )
+    payload = json.loads(result_file.read_text())
+    payload["per_type_metrics"] = {
+        "fabricated_doi": {"count": 6, "detection_rate": 0.5},
+        "wrong_venue": {"count": 4, "detection_rate": 0.5},
+        "valid": {"count": 10},
+    }
+    result_file.write_text(json.dumps(payload))
+    res = crf.check_freshness(results_dir, version="v1.2", data_dir=data_dir)
+    assert res.passed and res.stale_files == []
+
+
+@pytest.mark.skipif(not _REAL_RESULTS_DIR.is_dir(), reason="real results dir not present")
+def test_the_two_patched_claude_dev_results_are_caught_and_registered():
+    """Pins the finding: per-type over 633 positives, headline 606, and they are
+    in KNOWN_STALE so the guard stays green without forgetting them."""
+    res = crf.check_freshness(_REAL_RESULTS_DIR, version="v1.2", data_dir=_REAL_DATA_DIR)
+    by_name = {r.result_file: r for r in res.reports}
+    for name in (
+        "llm_openrouter_claude_opus_4_7_dev_public.json",
+        "llm_openrouter_claude_sonnet_4_6_dev_public.json",
+    ):
+        assert by_name[name].is_stale, f"{name} not flagged"
+        assert any("per_type" in reason for reason in by_name[name].reasons)
+        assert name in crf.KNOWN_STALE, f"{name} flagged but not registered"
+    assert res.passed, res.errors


### PR DESCRIPTION
Three artifact-level items from the critical pass over #36–#55, one commit each. No DR/FPR/F1 triple changes anywhere.

## `coverage_adjusted_f1` was left at `f1 × 1.0`

#52 rewrote `coverage` on both bibtex-updater results and left the derived field where it was, so each file contradicted the definition in `metrics.py` (`f1_hallucination × coverage`) and the leaderboard showed bibtex-updater un-penalised on the one column whose purpose is to penalise abstention.

| split | coverage | was | now |
|---|---|---|---|
| `dev_public` | 0.8624 | 0.8904 | **0.7679** |
| `test_public` | 0.8761 | 0.9010 | **0.7894** |

Under the committed-VALID triple this counts abstention twice (a committed miss inside F1, then coverage); the provenance string in each file says so, so the number reads as a lower bound rather than a third scoring. `rescore_btu_from_raw.py` writes the field from now on and the abstention test pins it.

## Two `dev_public` results are internally inconsistent, and one was scored

`llm_openrouter_claude_opus_4_7` and `llm_openrouter_claude_sonnet_4_6` carry per-type counts summing to **633** positives (the pre-relabel split) under headline counts of 606 / 513. The top-level fields were patched; the per-type block was not; the freshness count check saw the patched fields and passed. The fold ablation had dropped Opus 4.7 for not reproducing its MCC (0.6625 rebuilt vs 0.6828 published) and scored Sonnet 4.6 because it happened to land inside the 0.02 tolerance.

The freshness guard now requires per-type counts to sum to the split's positives, and both files are registered known-stale with the reason, on the same ratchet as the HaRC file. They need a re-run under the current labels, which costs API calls and is not done here.

## The fold ablation counted one result twice

`cascade_db_diagnosis_aggressive_*` and `cascade_db_diagnosis_evalmode_aggressive_*` are byte-identical on all three splits (`tool_name` is `cascade_db_diagnosis` in both). The script now drops a byte-identical input and names it. Regenerated tables and the README figures they feed:

| split | folded out | as false positives |
|---|---|---|
| `test_public` | tau 0.884, 13 of 20 (was 0.886, 14 of 21) | tau 0.821, 16 of 20 (was 0.829, 17 of 21) |
| `dev_public` | tau 0.906, 14 of 19 (was 0.905, 15 of 20) | tau 0.801, 16 of 19 (was 0.811, 17 of 20) |

Median detection rate on the four modes: 0.740 across 20 tools (was 0.755 across 21). Two README sentences corrected in passing: `stress_test` does carry one VALID entry, a contamination canary excluded from scoring; and folding `hybrid_fabrication` leaves the folded-out ranking unchanged but moves six tools under as-false-positives (tau 0.968 / 0.965), which "moves nothing" overstated. The section's conclusion is unchanged.

Not touched: `tables/base_rate_precision.csv` still carries both duplicate cascade rows; the duplicate result files themselves are left in place, since removing a released artifact is a separate call.

## Verification

`validate-results --strict --metadata`: passed. `check_results_freshness.py`: no unexpected staleness, 3 registered. Full suite 1,445 passed, 2 skipped. The three new tests fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp