### PR TITLE
chore: withdraw the HuggingFace mirror and repoint the metadata at this repo

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -11,7 +11,7 @@ Release and distribution plan for HALLMARK v1.0.
 | Anonymous review repo | https://anonymous.4open.science/r/hallmark/ | git | Double-blind review access |
 | GitHub | https://github.com/rpatrik96/hallmark | git | Canonical public release |
 | Companion website | https://rpatrik96.github.io/hallmark/ | static HTML (GitHub Pages, deployed from `site/`) | Interactive results explorer + examples browser |
-| HuggingFace mirror | https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK | parquet (canonical) + jsonl (mirror) + baseline_results + croissant.json | Dataset hosting |
+| HuggingFace mirror | withdrawn with the NeurIPS 2026 submission | — | — |
 | Zenodo DOI | planned at camera-ready | archive | Permanent archival + DOI minting |
 | PyPI | planned at camera-ready | wheel | `pip install hallmark` |
 
@@ -28,7 +28,7 @@ pip install mlcroissant
 mlcroissant validate --jsonld croissant.json
 ```
 
-The `distribution` block points to parquet files on the HuggingFace mirror; this is the canonical machine-readable target for `mlcroissant` streaming and the NeurIPS Records Generation Test. JSONL versions remain on the same mirror under `jsonl/` for direct human consumption.
+The `distribution` block points to the JSONL files in this repository under `data/v1.2/`; this is the canonical machine-readable target for `mlcroissant` streaming and the NeurIPS Records Generation Test.
 
 RAI fields covered (all required by NeurIPS 2026 D&B):
 `rai:dataCollection`, `rai:dataCollectionType`, `rai:personalSensitiveInformation`,
@@ -47,25 +47,12 @@ Full text: `LICENSE`.
 
 ## Checksums (SHA-256)
 
-### Parquet (canonical, referenced from `croissant.json`, hosted on HuggingFace)
+### JSONL (canonical, referenced from `croissant.json`)
 
 ```
-16cf8f28b28606515fadb7ddef489a1bd88ddf9414345b2b46da8e96f52bab4b  data/dev_public.parquet
-2f8c6d6c009c1ea6c37f53c4e0abb97c484e0c9a1fe098f06d0c457c7e6e1201  data/test_public.parquet
-cb273ad0a04d19320ceed78fee259728179e4886caf2accec660b93f33eab2db  data/stress_test.parquet
-b1b4f41ce89a2d43fb67ae961f22070b2e33b88a961c0d68994fe1b363ad9026  blind/dev_public_blind.parquet
-8c5c5104afbef57daa5d018c61fa979ee9eb9d740d9ea119f6bed15c21c47d5d  blind/test_public_blind.parquet
-3a1e0fdc263fe4c55ca1cc2526b0024eb270bcd6d02d4cc9cd9f8e908c0f9a3e  blind/stress_test_blind.parquet
-```
-
-Paths in this section are HuggingFace-relative (under `https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/`).
-
-### JSONL mirror (repo `data/v1.2/` and HuggingFace `jsonl/`)
-
-```
-d04a19f469765345febd5ca1a8c45edbe07c1937734edd695fd87f6184890a27  data/v1.2/dev_public.jsonl
+0f75d390f95a086aaf39b627369af2bd03a5eb87cd3bf4cea5d5025e203bb09e  data/v1.2/dev_public.jsonl
 46b9a23a1e1a7564c52ac490a492090fdc8d87f15bfea4c62bc49f8fd9ce42b7  data/v1.2/dev_public_blind.jsonl
-b06821c91398da9aecf35ce4cba0baf8eea6632f384e9984530e10bbd27ce45b  data/v1.2/test_public.jsonl
+0637ffc80747c36f3e010cd613f16481dcb916f944874122b2e2d3f872429973  data/v1.2/test_public.jsonl
 0461cef293e6f2a1e1448b6fa56de72c0efd18a240cdf426377616afc00649bd  data/v1.2/test_public_blind.jsonl
 af3a11606948fea8edccbbd5c512e6efd69c1f9056032d446f01c66950da07d3  data/v1.2/stress_test.jsonl
 cf6f829b2ad99c6badd9eb513214e2d811e6b0fe3218a64263aeecb690ea49e3  data/v1.2/stress_test_blind.jsonl
@@ -74,10 +61,10 @@ f6b5b3fcc7964a8b74be8a30b6c4566582d81f42764f2b1501d89d29ee2dfdbb  data/v1.2/sour
 3e772d02f71ae74601c419f6bfd6244f13acd329be61e003910cb9eb3c1f03b3  data/v1.2/valid_entry_verification.json
 ```
 
-Verify the JSONL mirror locally:
+Verify locally:
 
 ```bash
-shasum -a 256 --check <(grep "data/v1.2/" HOSTING.md | grep -v "^#")
+shasum -a 256 --check <(grep -E "^[0-9a-f]{64}  data/v1.2/" HOSTING.md)
 ```
 
 ---
@@ -102,8 +89,7 @@ Backward-compatible additions increment the minor version in-place.
 
 ## Anonymous review note
 
-Creator and contact metadata in `croissant.json`, `metadata.json`, and HuggingFace dataset
-cards are currently set to placeholder values to comply with NeurIPS 2026 double-blind review
+Creator and contact metadata in `croissant.json` and `metadata.json` are set to placeholder values to comply with NeurIPS 2026 double-blind review
 policy. All identifying fields will be populated at camera-ready. The anonymous review repository
 at https://anonymous.4open.science/r/hallmark/ provides read-only access to reviewers without
 revealing author identity.

--- a/README.md
+++ b/README.md
@@ -287,16 +287,13 @@ figures first. Discussion is in [issue #36](https://github.com/rpatrik96/hallmar
 
 ## Hosting & Croissant
 
-The dataset is mirrored on HuggingFace (parquet + jsonl + baseline results + RAI Croissant metadata):
-<https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK>
+The dataset ships in this repository under `data/v1.2/` as JSONL, so every split is available without an external download. The HuggingFace mirror published for the NeurIPS 2026 submission was withdrawn together with the submission.
 
-A [Croissant 1.0](https://mlcommons.org/croissant/) metadata file is included at the repo root (`croissant.json`). It covers all public splits and includes RAI fields required by NeurIPS 2026 D&B. Validate locally with:
+A [Croissant 1.0](https://mlcommons.org/croissant/) metadata file is included at the repo root (`croissant.json`) and points at the files in this repository. It covers all public splits and includes RAI fields required by NeurIPS 2026 D&B. Validate locally with:
 
 ```bash
 mlcroissant validate --jsonld croissant.json
 ```
-
-The data is also shipped in `data/v1.2/` for direct repo-relative access without any external download.
 
 ## Dataset
 

--- a/croissant.json
+++ b/croissant.json
@@ -77,65 +77,65 @@
     {
       "@type": "cr:FileObject",
       "@id": "dev-public-file",
-      "name": "dev_public.parquet",
+      "name": "dev_public.jsonl",
       "description": "Development split with ground-truth labels for model development and hyperparameter tuning.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/data/dev_public.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "16cf8f28b28606515fadb7ddef489a1bd88ddf9414345b2b46da8e96f52bab4b"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/dev_public.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "0f75d390f95a086aaf39b627369af2bd03a5eb87cd3bf4cea5d5025e203bb09e"
     },
     {
       "@type": "cr:FileObject",
       "@id": "test-public-file",
-      "name": "test_public.parquet",
+      "name": "test_public.jsonl",
       "description": "Public test split with ground-truth labels for evaluation and ablation studies.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/data/test_public.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "2f8c6d6c009c1ea6c37f53c4e0abb97c484e0c9a1fe098f06d0c457c7e6e1201"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/test_public.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "0637ffc80747c36f3e010cd613f16481dcb916f944874122b2e2d3f872429973"
     },
     {
       "@type": "cr:FileObject",
       "@id": "stress-test-file",
-      "name": "stress_test.parquet",
+      "name": "stress_test.jsonl",
       "description": "Stress-test split focusing on theoretically-motivated hallucination types (merged_citation, partial_author_list, arxiv_version_mismatch) evaluated separately from the main benchmark.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/data/stress_test.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "cb273ad0a04d19320ceed78fee259728179e4886caf2accec660b93f33eab2db"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/stress_test.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "af3a11606948fea8edccbbd5c512e6efd69c1f9056032d446f01c66950da07d3"
     },
     {
       "@type": "cr:FileObject",
       "@id": "dev-public-blind-file",
-      "name": "dev_public_blind.parquet",
+      "name": "dev_public_blind.jsonl",
       "description": "Blinded version of the development split (no ground-truth labels) for baseline runners.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/blind/dev_public_blind.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "b1b4f41ce89a2d43fb67ae961f22070b2e33b88a961c0d68994fe1b363ad9026"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/dev_public_blind.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "46b9a23a1e1a7564c52ac490a492090fdc8d87f15bfea4c62bc49f8fd9ce42b7"
     },
     {
       "@type": "cr:FileObject",
       "@id": "test-public-blind-file",
-      "name": "test_public_blind.parquet",
+      "name": "test_public_blind.jsonl",
       "description": "Blinded version of the public test split (no ground-truth labels) for baseline runners.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/blind/test_public_blind.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "8c5c5104afbef57daa5d018c61fa979ee9eb9d740d9ea119f6bed15c21c47d5d"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/test_public_blind.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "0461cef293e6f2a1e1448b6fa56de72c0efd18a240cdf426377616afc00649bd"
     },
     {
       "@type": "cr:FileObject",
       "@id": "stress-test-blind-file",
-      "name": "stress_test_blind.parquet",
+      "name": "stress_test_blind.jsonl",
       "description": "Blinded version of the stress-test split (no ground-truth labels) for baseline runners.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/blind/stress_test_blind.parquet",
-      "encodingFormat": "application/x-parquet",
-      "sha256": "3a1e0fdc263fe4c55ca1cc2526b0024eb270bcd6d02d4cc9cd9f8e908c0f9a3e"
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/stress_test_blind.jsonl",
+      "encodingFormat": "application/jsonlines",
+      "sha256": "cf6f829b2ad99c6badd9eb513214e2d811e6b0fe3218a64263aeecb690ea49e3"
     },
     {
       "@type": "cr:FileObject",
       "@id": "metadata-file",
       "name": "metadata.json",
       "description": "Dataset metadata including split statistics, type distributions, and generation method breakdowns.",
-      "contentUrl": "https://huggingface.co/datasets/hallmark-neurips2026/HALLMARK/resolve/main/metadata.json",
+      "contentUrl": "https://raw.githubusercontent.com/rpatrik96/hallmark/main/data/v1.2/metadata.json",
       "encodingFormat": "application/json",
-      "sha256": "caf4f5597846b4cbca404fb44e2c1550db69ae062288a78f7028f95bd7a3e065"
+      "sha256": "ea4f34bc80e844823b9604d880b0b4a7dec63cb1c193014969f6d7fe972751a0"
     }
   ],
   "recordSet": [
@@ -143,7 +143,7 @@
       "@type": "cr:RecordSet",
       "@id": "benchmark-entries",
       "name": "BenchmarkEntry",
-      "description": "Each record is an atomic benchmark entry representing a BibTeX citation to be verified. Entries are either VALID (scraped from real proceedings) or HALLUCINATED (synthetically generated with specific corruption patterns). Each entry includes 6 sub-test ground-truth labels. Note: nested dict columns 'fields' (BibTeX field map) and 'subtests' (per-entry sub-test labels) ship in the parquet files but are not declared as Croissant fields here; consult the dataset documentation for their schema.",
+      "description": "Each record is an atomic benchmark entry representing a BibTeX citation to be verified. Entries are either VALID (scraped from real proceedings) or HALLUCINATED (synthetically generated with specific corruption patterns). Each entry includes 6 sub-test ground-truth labels. Note: nested dict columns 'fields' (BibTeX field map) and 'subtests' (per-entry sub-test labels) are present in the JSONL records but are not declared as Croissant fields here; consult the dataset documentation for their schema.",
       "key": "bibtex_key",
       "field": [
         {
@@ -347,7 +347,7 @@
       "@type": "cr:RecordSet",
       "@id": "blind-entries",
       "name": "BlindEntry",
-      "description": "Privacy-preserving view of benchmark entries for baseline runners. Contains only the fields needed for verification -- ground-truth labels, difficulty tiers, and generation metadata are excluded to prevent baselines from accessing oracle information. Note: nested dict columns 'fields' (BibTeX field map) and 'subtests' (per-entry sub-test labels) ship in the parquet files but are not declared as Croissant fields here; consult the dataset documentation for their schema.",
+      "description": "Privacy-preserving view of benchmark entries for baseline runners. Contains only the fields needed for verification -- ground-truth labels, difficulty tiers, and generation metadata are excluded to prevent baselines from accessing oracle information. Note: nested dict columns 'fields' (BibTeX field map) and 'subtests' (per-entry sub-test labels) are present in the JSONL records but are not declared as Croissant fields here; consult the dataset documentation for their schema.",
       "key": "bibtex_key",
       "field": [
         {

--- a/hf/README.md
+++ b/hf/README.md
@@ -70,10 +70,10 @@ The paper's numbers are computed against tag `v1.2.0`. Later releases (`v1.2.1`,
 from datasets import load_dataset
 
 # Default config (all labels visible)
-ds = load_dataset("hallmark-neurips2026/HALLMARK")
+ds = load_dataset("<owner>/HALLMARK")
 
 # Blind config (labels stripped — for leaderboard submissions)
-blind = load_dataset("hallmark-neurips2026/HALLMARK", "blind")
+blind = load_dataset("<owner>/HALLMARK", "blind")
 ```
 
 The `default` config exposes the full schema with ground-truth labels. The `blind` config strips

--- a/scripts/upload_to_hf.py
+++ b/scripts/upload_to_hf.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""Refresh the HALLMARK HuggingFace mirror (hallmark-neurips2026/HALLMARK).
+"""Publish the HALLMARK corpus as a HuggingFace dataset mirror.
 
-ANONYMITY: the hub dataset is linked in the NeurIPS 2026 submission and must
-stay double-blind until the decision. Every staged file is scanned for
-de-anonymizing strings (author names, GitHub handle, arXiv ID) and the run
-aborts on a hit; pass --allow-deanonymized only after the review period ends.
+The mirror published for the NeurIPS 2026 submission was withdrawn together
+with the submission, so no mirror is live. The script stays for a future
+re-publication, which names its own target through --repo-name.
 
-Mirrors the LIVE hub layout (which differs from the repo layout):
+ANONYMITY: every staged file is scanned for de-anonymizing strings (author
+names, GitHub handle, arXiv ID) and the run aborts on a hit; pass
+--allow-deanonymized to publish under the authors' own identity. croissant.json
+serves the corpus from the GitHub repository and so carries the handle, which
+means a named re-publication needs that flag.
+
+Hub layout (which differs from the repo layout):
 
     jsonl/<split>.jsonl            <- data/v1.2/<split>.jsonl   (6 files)
     data/<split>.parquet           <- built from jsonl           (3 files)
@@ -18,15 +23,16 @@ Mirrors the LIVE hub layout (which differs from the repo layout):
     croissant.json                 <- croissant.json
     README.md                      <- hf/README.md (dataset card, tracked here)
 
-Parquet files are rebuilt deterministically (pandas + snappy) and their SHA-256
-is verified against croissant.json before anything is uploaded; metadata.json
-is verified the same way. A mismatch aborts the run. Everything ships as one
+Parquet files are rebuilt deterministically (pandas + snappy) from the JSONL.
+Every source file croissant.json declares -- the six JSONL splits and
+metadata.json -- has its SHA-256 verified against croissant.json before
+anything is uploaded. A mismatch aborts the run. Everything ships as one
 hub commit; unchanged blobs are deduplicated server-side.
 
 baseline_results/ on the hub is a separate artifact set and is not touched.
 
 Usage:
-    python scripts/upload_to_hf.py [--repo-name hallmark-neurips2026/HALLMARK]
+    python scripts/upload_to_hf.py --repo-name <owner>/<name>
                                    [--token <hf_token>] [--dry-run]
 
 Without --token the cached `hf auth login` credential is used.
@@ -43,6 +49,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = ROOT / "data" / "v1.2"
+
+# croissant.json serves the corpus from this repository, not from any hub mirror
+GITHUB_REPO = "rpatrik96/hallmark"
 
 JSONL_SPLITS = [
     "dev_public",
@@ -82,14 +91,16 @@ def sha256(path: Path) -> str:
 
 
 def croissant_checksums() -> dict[str, str]:
-    """Hub path -> expected sha256, from croissant.json's distribution block."""
+    """Repo-relative path -> expected sha256, from croissant.json's distribution."""
     spec = json.loads((ROOT / "croissant.json").read_text(encoding="utf-8"))
     expected = {}
     for obj in spec["distribution"]:
         url = obj.get("contentUrl", "")
-        marker = "/resolve/main/"
+        marker = f"/{GITHUB_REPO}/main/"
         if marker in url and "sha256" in obj:
             expected[url.split(marker, 1)[1]] = obj["sha256"]
+    if not expected:
+        sys.exit("croissant.json declares no checksummed file in this repository")
     return expected
 
 
@@ -112,7 +123,7 @@ def build_parquets(dst: Path) -> dict[Path, str]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Refresh the HALLMARK HuggingFace mirror")
-    parser.add_argument("--repo-name", default="hallmark-neurips2026/HALLMARK")
+    parser.add_argument("--repo-name", required=True, help="target hub repo, <owner>/<name>")
     parser.add_argument("--token", default=None, help="HF token (default: cached login)")
     parser.add_argument("--dry-run", action="store_true", help="verify + list, upload nothing")
     parser.add_argument(
@@ -139,21 +150,22 @@ def main() -> None:
             hits = [m.decode() for m in DEANONYMIZING_MARKERS if m in blob]
             if hits:
                 sys.exit(
-                    f"ANONYMITY VIOLATION: {hub_path} contains {hits}; the hub dataset "
-                    "is double-blind for NeurIPS 2026 review. Fix the file or, after "
-                    "the decision, rerun with --allow-deanonymized."
+                    f"ANONYMITY VIOLATION: {hub_path} contains {hits}; this run is "
+                    "staging an anonymized mirror. Fix the file, or rerun with "
+                    "--allow-deanonymized to publish under the authors' own identity."
                 )
         print("anonymity scan: clean")
 
-    expected = croissant_checksums()
-    by_hub = {hub: src for src, hub in uploads.items()}
-    for hub_path, want in expected.items():
-        got = sha256(by_hub[hub_path])
-        print(f"checksum {'ok' if got == want else 'MISMATCH'}: {hub_path}")
+    for rel_path, want in croissant_checksums().items():
+        src = ROOT / rel_path
+        if not src.exists():
+            sys.exit(f"croissant.json declares {rel_path}, which is not in the repository")
+        got = sha256(src)
+        print(f"checksum {'ok' if got == want else 'MISMATCH'}: {rel_path}")
         if got != want:
             sys.exit(
-                f"{hub_path}: sha256 {got} does not match croissant.json ({want}); "
-                "regenerate croissant.json or investigate non-determinism before uploading"
+                f"{rel_path}: sha256 {got} does not match croissant.json ({want}); "
+                "regenerate croissant.json before uploading"
             )
 
     for src, hub_path in sorted(uploads.items(), key=lambda kv: kv[1]):


### PR DESCRIPTION
The HuggingFace dataset mirror `hallmark-neurips2026/HALLMARK` was published for the NeurIPS 2026 submission. The submission is withdrawn, so the mirror goes with it and this repository stops claiming it exists.

## The deletion is still blocked

**The HF repo has NOT been deleted.** The cached token is invalid:

```
$ hf auth whoami
Invalid user token. The token stored is invalid. Please run `hf auth login` to update it.
{"error":"Invalid username or password."}
```

No deletion was attempted. The repo is still live as of this PR:

```
$ curl -s https://huggingface.co/api/datasets/hallmark-neurips2026/HALLMARK
{"id":"hallmark-neurips2026/HALLMARK", ... "lastModified":"2026-05-06T11:26:07.000Z",
 "private":false,"disabled":false, ... "downloads":57 ...}
```

That matches the expected target exactly, so the deletion is a one-liner once a valid token is in place:

```bash
uv run python -c "from huggingface_hub import HfApi; HfApi().delete_repo('hallmark-neurips2026/HALLMARK', repo_type='dataset')"
```

Deleting the `hallmark-neurips2026` org itself has no API and has to be done in the HuggingFace web UI.

## What changed here

- **`croissant.json`** — every `contentUrl` now points at the raw GitHub URL of the corresponding file in this repository. The distribution describes the six JSONL splits and `metadata.json` (`application/jsonlines` / `application/json`); the parquet files it used to name existed only on the mirror. All seven `sha256` values recomputed from the files. RAI fields and both record sets are unchanged, and `extract.column` is kept — mlcroissant reads JSONL into columns, so `jsonPath` breaks record generation.
- **`README.md`** — the Hosting & Croissant section says the corpus ships in `data/v1.2/` and that the mirror was withdrawn with the submission.
- **`HOSTING.md`** — the HuggingFace row reads "withdrawn with the NeurIPS 2026 submission"; the parquet checksum block is gone along with the sentence calling the paths HuggingFace-relative. Two JSONL checksums were separately stale (7c3559b changed `dev_public` and `test_public` without updating them) and are refreshed, and the documented verify command is anchored on the hash so it stops flagging prose lines.
- **`scripts/upload_to_hf.py`** — `--repo-name` is now required rather than defaulting to the withdrawn repo, and the docstring says the mirror was withdrawn and the script is here for a future re-publication. `croissant_checksums()` keyed on HuggingFace's `/resolve/main/` marker, which the new `contentUrl`s do not contain, so it would have returned an empty dict and silently verified nothing; it now reads the repo-relative paths and exits if the match comes back empty.
- **`hf/README.md`** — the staged dataset card's two `load_dataset` examples named the dead repo; now `<owner>/HALLMARK`.

## Verification

- `uvx --from mlcroissant mlcroissant validate --jsonld croissant.json` → `Done.` (no issues)
- Record generation over the live URLs succeeds for both record sets, which also confirms every declared SHA-256 against the file fetched from `raw.githubusercontent.com`.
- `shasum -a 256 --check` on HOSTING.md's block → all 9 OK.
- `uv run python scripts/upload_to_hf.py --repo-name someone/HALLMARK --dry-run --allow-deanonymized` → all 7 checksums ok; without `--repo-name` argparse now refuses.
- `uv run python -m pytest -q tests/` → 1439 passed, 2 skipped.
- `uv run ruff check .` → clean; `ruff format --check` → 284 files already formatted; `mypy` → clean.

## Left for a decision

The anonymity scan in `upload_to_hf.py` now always trips in its default mode, because `croissant.json` legitimately carries `rpatrik96` in the raw GitHub URLs. The guard and its `--allow-deanonymized` escape hatch are kept as they were and the docstring says a named re-publication needs the flag, but with the submission withdrawn the double-blind default may no longer be worth having. Related: `croissant.json`'s `creator` is still `Anonymous`, its `url` still points at anonymous.4open.science, and `HOSTING.md` still carries the anonymous-review note — de-anonymizing those is a separate call and was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2TR6riirupzxgSkNFGBcp
