### PR TITLE
bibtexupdater wrapper: render unconfirmed fields distinctly; retire pre-flip subtest narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,13 @@ The `[baselines]` extra installs only the LLM SDKs (`openai`, `anthropic`). Exte
 # HaRC
 pipx install harcx
 
-# bibtex-updater (released HALLMARK numbers use tag v1.2.0)
-pipx install "bibtex-updater==1.2.0"
+# bibtex-updater. The wrapper targets >=1.11.0, which separates fields the
+# checker refuted (`mismatched_fields`) from fields it declined to compare
+# (`unconfirmed_fields`); older releases still parse, minus that distinction.
+pipx install "bibtex-updater>=1.11.0"
+# To reproduce released numbers, pin the release that produced them:
+#   dev/test tables            -> 1.2.0  (scripts/regen_btu_v1_2_0.py, 2026-05-31)
+#   Walters & Wilder supplement -> 1.4.0  (docs/walters_wilder_supplement.md, 2026-07)
 
 # verify-citations
 pipx install verify-citations

--- a/docs/walters_wilder_supplement.md
+++ b/docs/walters_wilder_supplement.md
@@ -77,7 +77,9 @@ All 341 pass `hallmark.contribution.validate_entry.validate_batch`. Built by
 
 ## 4. bibtexupdater evaluation
 
-`bibtex-check` (bibtex-updater 1.4.0), `--academic-only`, via the HALLMARK
+`bibtex-check` (bibtex-updater 1.4.0 — the current release when this supplement
+was run in 2026-07; the main dev/test tables were produced earlier with 1.2.0, see
+README), `--academic-only`, via the HALLMARK
 wrapper (`hallmark/baselines/bibtexupdater.py`) and `hallmark.evaluation.evaluate`.
 Full coverage 341/341 (the run took ~4 h of wall-clock under sustained Semantic
 Scholar / OpenAlex rate-limiting — the documented shared-IP throttling). Reference

--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -25,6 +25,16 @@ as before (the precomputed reference results are unaffected):
 - ``p_valid`` (float in [0, 1]): explicit P(entry as cited is genuine) — the
   value to threshold on.  When present it replaces the older realness
   inversion heuristic for deriving ``Prediction.confidence``.
+- ``unconfirmed_fields`` (bibtex-updater >= 1.11.0): fields the checker
+  deliberately declined to compare (NON_COMPARABLE / PARTIAL).  Through 1.10.3
+  these were folded into ``mismatched_fields``, so an abstention on ``venue``
+  read as a venue the checker had refuted — on a 5,043-reference corpus 956 of
+  1,024 venue-only entries were abstentions, not contradictions.  1.11.0 narrows
+  ``mismatched_fields`` to real contradictions and moves abstentions to this
+  additive key.  The wrapper renders the two distinctly in ``reason``
+  (``Mismatched: [...]`` vs ``Unconfirmed (not compared): [...]``); labels are
+  derived from ``status`` alone and are unaffected.  On older releases the key
+  is simply absent and ``reason`` reads exactly as before.
 
 Every invocation is scored by a batch-level sanity check (``assess_batch_health``)
 before the results are handed back.  ``not_found`` is evidence of fabrication only
@@ -915,7 +925,8 @@ def parse_jsonl_to_raw(jsonl_path: Path) -> dict[str, dict]:
 
     Returns:
         Mapping from bibtex_key to the full raw record dict containing status,
-        mismatched_fields, api_sources, confidence, errors, etc.
+        mismatched_fields, unconfirmed_fields (>= 1.11.0), api_sources,
+        confidence, errors, etc.
     """
     records: dict[str, dict] = {}
     with open(jsonl_path) as f:
@@ -957,7 +968,10 @@ def _parse_jsonl_output(
             key = record.get("key", "")
             status = record.get("status", "skipped")
             raw_confidence = record.get("confidence", STATUS_TO_CONFIDENCE.get(status, 0.5))
-            mismatched = record.get("mismatched_fields", [])
+            mismatched = record.get("mismatched_fields") or []
+            # >= 1.11.0 only; absent on older releases, where abstained fields
+            # were folded into ``mismatched_fields``.
+            unconfirmed = record.get("unconfirmed_fields") or []
             api_sources = record.get("api_sources", [])
             errors = record.get("errors", [])
             p_valid = record.get("p_valid")
@@ -1039,8 +1053,14 @@ def _parse_jsonl_output(
                     "Lookup incomplete due to source errors/throttling — "
                     "abstention, not evidence of fabrication"
                 )
+            # A contradiction and an abstention must not read the same way to
+            # someone auditing the output: ``mismatched_fields`` is what the
+            # checker refuted, ``unconfirmed_fields`` is what it declined to
+            # compare (issue #37).
             if mismatched:
                 reason_parts.append(f"Mismatched: {mismatched}")
+            if unconfirmed:
+                reason_parts.append(f"Unconfirmed (not compared): {unconfirmed}")
             if errors:
                 reason_parts.append(f"Errors: {errors}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dev = [
 all = ["hallmark[baselines,ranking,scraping,analysis,dev]"]
 # NOTE: bibtex-updater and harcx require bibtexparser 1.x which conflicts
 # with hallmark's bibtexparser>=2.0. Install them in isolation:
-#   pipx install "bibtex-updater==1.2.0"  # released HALLMARK numbers use tag v1.2.0
+#   pipx install "bibtex-updater>=1.11.0"  # wrapper target; released dev/test numbers
+#                                          # used 1.2.0, the W&W supplement 1.4.0 (README)
 #   pipx install harcx
 
 [project.scripts]

--- a/scripts/fix_subtest_type_contradictions.py
+++ b/scripts/fix_subtest_type_contradictions.py
@@ -14,19 +14,20 @@ sources agree on ``False``: ``EXPECTED_SUBTESTS``, the semantics of the type,
 and every entry of that type in the public splits (which carry zero mismatches
 of this direction).
 
-Deliberately NOT repaired
--------------------------
-``future_date`` / ``fields_complete``. ``EXPECTED_SUBTESTS`` says ``False``, but
-running the real checker settles it the other way: ``check_fields_complete``
-tests for missing required fields plus a 4-digit year and a well-formed DOI, and
-a future-dated entry has all its fields with a perfectly well-formed year. Run
-against every ``future_date`` entry, the checker returns ``True`` for 14 of 15
-in the hidden split (which assign ``True``) and for 29 of 30 in ``dev_public``
-(which assign ``False``). So the hidden data is right, the taxonomy entry is
-wrong, and it is the public splits that carry 29 contradictions of the checker.
-Repairing the hidden entries to match the taxonomy would corrupt correct data.
-Fixing that properly means changing ``EXPECTED_SUBTESTS`` and re-labelling
-public released entries, which is a bigger decision than this script.
+Deliberately NOT repaired here
+-----------------------------
+``future_date`` / ``fields_complete``. When this script was written,
+``EXPECTED_SUBTESTS`` said ``False`` for that pair while the real checker
+(``check_fields_complete``: required fields present, 4-digit year, well-formed
+DOI) returned ``True`` for every well-formed future-dated entry, so the hidden
+split, which assigned ``True``, was right and the taxonomy entry was wrong.
+Repairing the hidden entries to match the taxonomy would have corrupted correct
+data, so the pair was excluded from :data:`CONTRADICTIONS`. The taxonomy has
+since been fixed (``EXPECTED_SUBTESTS[FUTURE_DATE]["fields_complete"]`` is now
+``True``) and 82 public labels were aligned with the checker's per-entry
+verdict; see ``results/reviewer_experiments/fields_complete_future_date_alignment.json``.
+The pair stays out of this script because its repair went the other way (public
+splits, ``False -> True``) and is already done.
 
 Usage
 -----

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -217,6 +217,105 @@ class TestParseJsonlOutput:
         assert "throttling" not in pred.reason
 
 
+class TestFieldRendering:
+    """``mismatched_fields`` vs ``unconfirmed_fields`` in ``reason`` (issue #37).
+
+    Through bibtex-updater 1.10.3 a field the checker declined to compare was
+    reported under ``mismatched_fields``; 1.11.0 narrows that key to real
+    contradictions and moves abstentions to the additive ``unconfirmed_fields``.
+    The label is derived from ``status`` alone, so only ``reason`` changes, and
+    the two kinds of finding must read differently to a human auditing it.
+    """
+
+    def test_both_keys_present_render_distinctly(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "unconfirmed",
+                "p_valid": 0.5,
+                "mismatched_fields": ["year"],
+                "unconfirmed_fields": ["venue"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.reason.startswith("Status: unconfirmed")
+        assert "Mismatched: ['year']" in pred.reason
+        assert "Unconfirmed (not compared): ['venue']" in pred.reason
+        # The contradiction is listed before the abstention.
+        assert pred.reason.index("Mismatched:") < pred.reason.index("Unconfirmed (not compared):")
+
+    def test_pre_1_11_record_without_unconfirmed_key(self, tmp_path: Path) -> None:
+        """Older releases have no ``unconfirmed_fields``; the reason reads
+        exactly as before."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "venue_mismatch",
+                "confidence": 0.8,
+                "mismatched_fields": ["venue"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "HALLUCINATED"
+        assert pred.reason == "Status: venue_mismatch; Mismatched: ['venue']"
+        assert "Unconfirmed" not in pred.reason
+
+    def test_only_unconfirmed_present_is_not_called_a_mismatch(self, tmp_path: Path) -> None:
+        """The 1.11.0 case the issue is about: a venue abstention must no
+        longer be rendered as ``Mismatched: ['venue']``."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "unconfirmed",
+                "p_valid": 0.5,
+                "mismatched_fields": [],
+                "unconfirmed_fields": ["venue"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert "Mismatched" not in pred.reason
+        assert "Unconfirmed (not compared): ['venue']" in pred.reason
+
+    def test_both_keys_empty_add_nothing(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "verified",
+                "p_valid": 0.94,
+                "mismatched_fields": [],
+                "unconfirmed_fields": [],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.reason == "Status: verified"
+
+    def test_null_field_lists_are_tolerated(self, tmp_path: Path) -> None:
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "verified",
+                "mismatched_fields": None,
+                "unconfirmed_fields": None,
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.reason == "Status: verified"
+
+    def test_label_is_unaffected_by_field_lists(self, tmp_path: Path) -> None:
+        """Scope check from the issue: the label comes from ``status`` only."""
+        records: list[dict[str, Any]] = [
+            {
+                "key": "k",
+                "status": "verified",
+                "p_valid": 0.9,
+                "mismatched_fields": ["venue"],
+                "unconfirmed_fields": ["year"],
+            }
+        ]
+        (pred,) = _parse(tmp_path, records)
+        assert pred.label == "VALID"
+
+
 class TestTransportStatusMapping:
     """A failed lookup is an abstention, never evidence of fabrication."""
 

--- a/tests/test_verify_subtests.py
+++ b/tests/test_verify_subtests.py
@@ -251,14 +251,17 @@ class TestSubtestConsistencyGate:
     def test_exemptions_are_still_needed(self, report):
         """An exemption that no longer fires is a stale excuse — drop it.
 
-        Skipped without the hidden split, and that is the point rather than a
-        convenience: the only entries currently exercising the
-        ``future_date``/``fields_complete`` exemption are in ``test_hidden``,
-        because the public splits assign ``False`` there and so agree with the
-        (wrong) taxonomy. Asserting staleness over a population that cannot
-        contain the cause would report a live exemption as dead — the same
-        population-dependent mistake this gate was split apart to stop making.
+        With ``CONTRADICTION_EXEMPTIONS`` empty there is nothing to check and the
+        test passes vacuously by design; the assertion only has teeth once an
+        exemption is added. When it is, the check needs the hidden split: an
+        exemption typically exists because one split contradicts the taxonomy
+        while the others agree with it, so asserting staleness over a population
+        that cannot contain the cause would report a live exemption as dead —
+        the same population-dependent mistake this gate was split apart to
+        stop making. Hence the skip, not a pass, when the split is absent.
         """
+        if not CONTRADICTION_EXEMPTIONS:
+            return
         if not (_REPO_ROOT / vs.DEFAULT_SPLITS["test_hidden"]).exists():
             pytest.skip("hidden split not present — exemption staleness not checkable")
 


### PR DESCRIPTION
Closes #37. Refs #40.

## #37 — an abstained field no longer reads as a contradiction

bibtex-updater 1.11.0 split the old `mismatched_fields` into real contradictions (`mismatched_fields`) and fields the checker declined to compare (`unconfirmed_fields`). The wrapper only ever rendered the first, so an abstention and a finding read identically in `reason` (`Mismatched: ['venue']`) — a 14:1 ratio on the InterpScience corpus.

- `hallmark/baselines/bibtexupdater.py`: `_parse_jsonl_output` reads `unconfirmed_fields` and appends `Unconfirmed (not compared): [...]` after `Mismatched: [...]`. Absent or `null` (pre-1.11.0 output) is a no-op, so the old reason string is byte-identical. Labels are unchanged: they still derive from `status` alone.
- `tests/test_bibtexupdater.py`: new `TestFieldRendering` covering both keys present, only mismatched (old shape), only unconfirmed, both empty, `None` lists, and label independence.
- Version pinning: the three versions in the repo describe two runs, not a contradiction. The released dev/test tables were regenerated 2026-05-31 (`scripts/regen_btu_v1_2_0.py`, #11), when 1.2.0 was the only release available; the Walters & Wilder supplement is a separate 2026-07-13 run at 1.4.0. README, `pyproject.toml` and the supplement now say which run each version belongs to, and the install line targets `>=1.11.0` for the new key. The 1.2.0 attribution rests on release dates and the pinned raw histogram test, not on a `tool_version` field, which the result JSONs do not carry.

Not changed: `llm_tool_augmented.py` and `_agentic_tools.py` also consume `mismatched_fields`, but as prompt evidence for LLM baselines. Adding an unconfirmed line there would change what released LLM baselines see, so that is left as a separate decision.

## #40 — stale documentation only

#39 repaired the ratchet and the later taxonomy flip made the deferred `future_date` decision. Verified against `main`: the gate is split by direction (`MAX_TYPE_CONTRADICTIONS = 0`, public 101 / hidden 42), it skips rather than passes without the hidden split, `fix_doi_resolves_na.py` includes `test_hidden`, and `CONTRADICTION_EXEMPTIONS` is empty. Two places still described the pre-flip world:

- `scripts/fix_subtest_type_contradictions.py`: the "deliberately not repaired" section said the taxonomy was wrong and the fix was a bigger decision. It now says the decision was made and why the pair stays out of this script.
- `test_exemptions_are_still_needed` narrated the retired exemption as live and emitted a CI skip that read as an unchecked guard with nothing left to check. It now returns when there are no exemptions and only skips for the missing split when one needs it.

No data, constants or assertions change. The one thing from #40's triage still outstanding is the residual 13 hidden-split per-entry label errors, which were absorbed into the hidden baseline rather than fixed.

## Checks

`ruff format --check .` clean, `ruff check` clean, `mypy --ignore-missing-imports hallmark/` clean, full suite 1453 passed / 18 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmSofWhgu6iHTK3FbE8Vz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmSofWhgu6iHTK3FbE8Vz2)_