### PR TITLE
The tier-weight sweep compared rankings computed at two different weight scales

### DIFF
--- a/hallmark/evaluation/ranking_stability.py
+++ b/hallmark/evaluation/ranking_stability.py
@@ -274,7 +274,7 @@ def ranking_sensitivity_analysis(
 
     for w in weight_samples:
         # Scale to sum to 6 (like default 1+2+3=6) for comparable magnitudes
-        weights = {1: float(w[0]) * 3, 2: float(w[1]) * 3, 3: float(w[2]) * 3}
+        weights = {1: float(w[0]) * 6, 2: float(w[1]) * 6, 3: float(w[2]) * 6}
         scores = _compute_twf1(weights)
         ranking = sorted(scores.items(), key=lambda x: -x[1])
         order = [t for t, _ in ranking]

--- a/tests/test_ranking_stability.py
+++ b/tests/test_ranking_stability.py
@@ -10,6 +10,7 @@ from hallmark.evaluation.ranking_stability import (
     _kendall_tau,
     iia_violation_check,
     per_subtype_ranking_stability,
+    ranking_sensitivity_analysis,
 )
 
 
@@ -101,6 +102,33 @@ class TestPerSubtypeRankingStability:
 
 
 class TestRankingSensitivity:
+    def test_uniform_tier_detection_rates_preserve_reference_ranking(self):
+        entries = [
+            _entry(f"h{tier}_{i}", "HALLUCINATED", tier=tier)
+            for tier in (1, 2, 3)
+            for i in range(2)
+        ] + [_entry(f"v{i}", "VALID") for i in range(8)]
+        tool_predictions = {
+            "high_recall_with_false_positives": [
+                _pred(entry.bibtex_key, "HALLUCINATED") for entry in entries
+            ],
+            "lower_recall_without_false_positives": [
+                _pred(
+                    entry.bibtex_key,
+                    (
+                        "HALLUCINATED"
+                        if entry.label == "HALLUCINATED" and entry.bibtex_key.endswith("_0")
+                        else "VALID"
+                    ),
+                )
+                for entry in entries
+            ],
+        }
+
+        result = ranking_sensitivity_analysis(entries, tool_predictions, n_samples=100, seed=0)
+
+        assert result.concordance_fraction == 1.0
+
     def test_requires_numpy(self):
         from unittest.mock import patch
 


### PR DESCRIPTION
Finding H1-1 of the 2026-09-06 review, reproduced by the verifier before the fix.

`ranking_sensitivity_analysis` in `hallmark/evaluation/ranking_stability.py` computed its reference ranking at the default weights (sum 6) and every sampled ranking at Dirichlet weights scaled to sum to 3, against a comment that already said "scale to sum to 6". While the tier-weighted F1 ignored false positives the score was scale-invariant and the mismatch was invisible. After #39 made `total_fp` real, the function returned an inverted verdict on every call: `rankings_stable=False`, concordance 0.0, 300 of 300 inversions, `kendall_tau_min = -1.0` on input where every sample agrees with every other.

The fix is the single multiplier. On the identical input it now reports `rankings_stable=True`, concordance 1.0, 0 inversions. Any "rankings are stable under tier reweighting" statement produced by this function since #39 should be regenerated.

Test: concordance pinned at 1.0 for two tools with uniform per-tier detection rates (fails at 0.0 on the pre-fix code). The existing sweep test checked only per-tool ranges and cannot see this class of defect. Full suite 1455 passed / 17 skipped; ruff and mypy clean. Diff produced by codex from the review's specification and read before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
