### PR TITLE
A prediction the tool never made no longer scores as a committed VALID

### DIFF
--- a/hallmark/dataset/schema.py
+++ b/hallmark/dataset/schema.py
@@ -576,6 +576,9 @@ class EvaluationResult:
     # predictions were manufactured because the tool was unavailable; zero means
     # the run measured nothing and its rates are artefacts of that, not results.
     num_evaluated: int | None = None
+    # Legacy per-entry failures carry this prose marker but predate the
+    # ``evaluated`` flag, so report them separately from ``num_evaluated``.
+    num_error_fallbacks: int | None = None
 
     # Tier 3 hard subset metric (Hardt benchmark science)
     tier3_f1: float = 0.0  # F1 on Tier 3 (hard) hallucinations only
@@ -602,9 +605,10 @@ class EvaluationResult:
     # covered — otherwise a tool that abstains on the hard entries reports its
     # easy-subset metrics at full coverage.
     coverage: float = 1.0
-    # ``response_coverage`` is the weaker "did the tool return a record at all"
-    # fraction, and is what strict mode checks for missing predictions.
-    response_coverage: float = 1.0
+    # ``response_coverage`` is the weaker "did the tool return a real-evaluation
+    # record" fraction, and is what strict mode checks for missing or manufactured
+    # predictions. None means a historical result did not record this metric.
+    response_coverage: float | None = None
     coverage_adjusted_f1: float = 0.0  # F1 * coverage, penalizes selective abstention
 
     # Type-level diagnosis metrics (populated when predicted_hallucination_type is set)

--- a/hallmark/evaluation/metrics.py
+++ b/hallmark/evaluation/metrics.py
@@ -10,12 +10,12 @@ Evaluation Protocol:
 1. **Prediction Labels**:
    - Tools must return VALID or HALLUCINATED predictions
    - UNCERTAIN is accepted as a valid label — see UNCERTAIN Protocol below
-   - Missing predictions are treated as VALID (conservative default)
+   - Missing and unevaluated predictions are excluded from classification metrics
 
 2. **UNCERTAIN Protocol**:
    - UNCERTAIN predictions are excluded from all classification metrics (DR, FPR, F1, TW-F1).
      The tool did respond, but with insufficient confidence to make a definitive call.
-   - UNCERTAIN predictions COUNT toward coverage (the tool processed the entry).
+   - UNCERTAIN predictions count toward response coverage, but not selective-prediction coverage.
    - UNCERTAIN predictions are excluded from AUROC and AUPRC (same as before).
    - UNCERTAIN predictions are excluded from ECE (no reliable confidence signal).
    - ``num_uncertain`` in EvaluationResult tracks how many were skipped.
@@ -33,7 +33,7 @@ Evaluation Protocol:
 
 5. **Metrics Computation**:
    - UNCERTAIN predictions excluded from classification metrics (see UNCERTAIN Protocol)
-   - Missing predictions treated as VALID (conservative default)
+   - Missing and unevaluated predictions excluded from classification metrics
    - Tier-weighted F1: harder hallucinations (Tier 3) weighted 3x vs Tier 1
    - ECE (Expected Calibration Error): measures confidence calibration
    - Per-type metrics: detection rate by hallucination type
@@ -64,6 +64,7 @@ from hallmark.dataset.schema import (
     Prediction,
     is_canary_entry,
 )
+from hallmark.evaluation.selective import is_error_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -159,16 +160,19 @@ def run_evaluated_nothing(predictions: list) -> bool:
     return evaluated_count(predictions) == 0
 
 
+def is_answer(pred: Prediction | None) -> bool:
+    """True when a prediction records a definite judgement from the tool."""
+    return pred is not None and pred.label != "UNCERTAIN" and getattr(pred, "evaluated", True)
+
+
 def build_confusion_matrix(
     entries: list[BenchmarkEntry],
     predictions: dict[str, Prediction] | list[Prediction],
 ) -> ConfusionMatrix:
     """Build confusion matrix from entries and predictions.
 
-    UNCERTAIN Protocol: UNCERTAIN predictions are excluded from the confusion matrix
-    entirely — they do not contribute to TP, FP, TN, or FN. They count toward
-    coverage (the tool did respond) but not toward classification metrics.
-    Missing predictions are treated as VALID (conservative default).
+    UNCERTAIN, unevaluated, and missing predictions are excluded from the
+    confusion matrix entirely — they do not contribute to TP, FP, TN, or FN.
 
     Args:
         entries: Benchmark entries (ground truth).
@@ -188,17 +192,9 @@ def build_confusion_matrix(
             pred = predictions[idx] if idx < len(predictions) else None  # type: ignore[index]
         else:
             pred = pred_map_cm.get(entry.bibtex_key)
-        if pred is None:
-            # Missing prediction treated as "VALID" (conservative)
-            if entry.label == "HALLUCINATED":
-                cm.fn += 1
-            else:
-                cm.tn += 1
+        if not is_answer(pred):
             continue
-
-        # UNCERTAIN excluded from classification metrics — skip this entry entirely
-        if pred.label == "UNCERTAIN":
-            continue
+        assert pred is not None
 
         if entry.label == "HALLUCINATED":
             if pred.label == "HALLUCINATED":
@@ -221,7 +217,7 @@ def tier_weighted_f1(
     """Compute F1 weighted by difficulty tier (Tier 3 worth 3x Tier 1).
 
     Each hallucinated entry contributes to F1 proportionally to its tier weight.
-    UNCERTAIN predictions are excluded (not counted toward the confusion matrix).
+    UNCERTAIN, unevaluated, and missing predictions are excluded.
 
     FP weighting note:
     - False positives (valid entries incorrectly flagged) are always weighted at 1.0,
@@ -256,12 +252,11 @@ def tier_weighted_f1(
         tier = entry.difficulty_tier or 1
         w = tier_weights.get(tier, 1.0)
 
-        # UNCERTAIN predictions are excluded from classification metrics entirely.
-        # Missing predictions are treated as VALID (conservative default).
-        if pred is not None and pred.label == "UNCERTAIN":
+        if not is_answer(pred):
             continue
 
-        pred_label = pred.label if pred is not None else "VALID"
+        assert pred is not None
+        pred_label = pred.label
 
         if entry.label == "HALLUCINATED":
             if pred_label == "HALLUCINATED":
@@ -389,8 +384,8 @@ def per_tier_metrics(
 ) -> dict[int, dict[str, float]]:
     """Compute metrics broken down by difficulty tier.
 
-    VALID entries (difficulty_tier=None) are included in ALL tiers' FPR
-    denominators, not assigned to tier 1. This ensures each tier reports a
+    Answered VALID entries (difficulty_tier=None) are included in ALL tiers'
+    FPR denominators, not assigned to tier 1. This ensures each tier reports a
     meaningful FPR rather than tier 1 absorbing all false positives and tiers
     2-3 showing 0.0 FPR.
 
@@ -398,10 +393,11 @@ def per_tier_metrics(
     - hallucinated entries of that tier (for detection rate / recall)
     - ALL valid entries across all tiers (for FPR)
     """
+    answered_entries = [e for e in entries if is_answer(predictions.get(e.bibtex_key))]
     # Separate valid from hallucinated entries
-    valid_entries = [e for e in entries if e.label == "VALID"]
+    valid_entries = [e for e in answered_entries if e.label == "VALID"]
     hall_by_tier: dict[int, list[BenchmarkEntry]] = defaultdict(list)
-    for entry in entries:
+    for entry in answered_entries:
         if entry.label == "HALLUCINATED":
             tier = entry.difficulty_tier or 1
             hall_by_tier[tier].append(entry)
@@ -429,13 +425,13 @@ def per_type_metrics(
 ) -> dict[str, dict[str, float]]:
     """Compute metrics broken down by hallucination type.
 
-    VALID entries are included in EVERY type's FPR denominator, mirroring
-    :func:`per_tier_metrics`. Grouping strictly by ``hallucination_type`` puts
-    only hallucinated entries in a type's group, which forces precision to 1.0
-    and FPR to 0.0 and collapses F1 to the deterministic ``2*DR/(1+DR)``. The
-    ``"valid"`` group keeps its own semantics: it has no hallucinated entries,
-    so its detection rate and F1 are 0.0 by definition and its FPR is the
-    tool's overall FPR.
+    Answered VALID entries are included in EVERY type's FPR denominator,
+    mirroring :func:`per_tier_metrics`. Grouping strictly by
+    ``hallucination_type`` puts only hallucinated entries in a type's group,
+    which forces precision to 1.0 and FPR to 0.0 and collapses F1 to the
+    deterministic ``2*DR/(1+DR)``. The ``"valid"`` group keeps its own
+    semantics: it has no hallucinated entries, so its detection rate and F1 are
+    0.0 by definition and its FPR is the tool's overall FPR.
 
     For each hallucination type the confusion matrix is built from:
     - hallucinated entries of that type (for detection rate / recall)
@@ -445,23 +441,23 @@ def per_type_metrics(
         entries: Benchmark entries.
         predictions: Tool's predictions — either a dict keyed by bibtex_key
             or a list of Prediction objects (converted internally).
-        compute_ci: If True, add Wilson score 95% CI keys ``dr_ci_lower`` and
-            ``dr_ci_upper`` for detection rate per type. CI is only meaningful
-            for hallucinated types (n > 0); valid entries get 0.0/0.0.
+        compute_ci: Retained for API compatibility. Wilson score 95% CI keys
+            ``dr_ci_lower`` and ``dr_ci_upper`` are always added. CI is only
+            meaningful for hallucinated types (n > 0); valid entries get 0.0/0.0.
 
     Returns:
         Dict mapping hallucination type to metrics dict. ``count`` is the
         number of hallucinated entries of that type (for ``"valid"``, the
         number of valid entries) and excludes the borrowed valid entries.
-        ``num_valid`` records how many valid entries entered the FPR
-        denominator. When ``compute_ci`` is True, each inner dict also
-        contains ``dr_ci_lower`` and ``dr_ci_upper``.
+        ``num_valid`` counts borrowed valid entries and is 0 on the ``"valid"``
+        row. Each inner dict also contains ``dr_ci_lower`` and ``dr_ci_upper``.
     """
     if isinstance(predictions, list):
         predictions = {p.bibtex_key: p for p in predictions}
-    valid_entries = [e for e in entries if e.label == "VALID"]
+    answered_entries = [e for e in entries if is_answer(predictions.get(e.bibtex_key))]
+    valid_entries = [e for e in answered_entries if e.label == "VALID"]
     type_entries: dict[str, list[BenchmarkEntry]] = defaultdict(list)
-    for entry in entries:
+    for entry in answered_entries:
         h_type = entry.hallucination_type or "valid"
         type_entries[h_type].append(entry)
 
@@ -579,7 +575,7 @@ def expected_calibration_error(
     Confidence represents the tool's belief in its own prediction: a tool
     predicting HALLUCINATED with confidence 0.9 claims 90% certainty.
 
-    UNCERTAIN predictions are excluded from ECE entirely (no reliable confidence signal).
+    UNCERTAIN and unevaluated predictions are excluded from ECE entirely.
 
     Args:
         entries: Benchmark entries (ground truth).
@@ -608,13 +604,10 @@ def expected_calibration_error(
             pred = predictions[idx] if idx < len(predictions) else None  # type: ignore[index]
         else:
             pred = pred_map_ece.get(entry.bibtex_key)
-        if pred is None:
+        if not is_answer(pred):
             continue
 
-        # UNCERTAIN excluded from ECE (consistent with AUROC/AUPRC treatment)
-        if pred.label == "UNCERTAIN":
-            continue
-
+        assert pred is not None
         is_correct = pred.label == entry.label
         pairs.append((pred.confidence, is_correct))
 
@@ -676,10 +669,10 @@ def auroc(
     Positive class: HALLUCINATED. Score = confidence for HALLUCINATED predictions,
     (1 - confidence) for VALID predictions.
 
-    Missing predictions and UNCERTAIN predictions are excluded from the AUROC
+    Missing, unevaluated, and UNCERTAIN predictions are excluded from the AUROC
     computation entirely (not assigned a neutral score of 0.5). This avoids
-    artificially inflating or deflating AUROC by treating absence of a prediction
-    as weak evidence. Only entries with a definite HALLUCINATED or VALID prediction
+    artificially inflating or deflating AUROC by treating absence of an answer
+    as weak evidence. Only entries with a definite HALLUCINATED or VALID answer
     are included.
 
     Returns None if fewer than 2 classes present among the included entries.
@@ -702,10 +695,11 @@ def auroc(
     for entry in entries:
         pred = predictions.get(entry.bibtex_key)
 
-        # Skip missing predictions and UNCERTAIN (no reliable score available)
-        if pred is None or pred.label == "UNCERTAIN":
+        # Skip missing, unevaluated, and UNCERTAIN predictions.
+        if not is_answer(pred):
             continue
 
+        assert pred is not None
         score = pred.confidence if pred.label == "HALLUCINATED" else 1.0 - pred.confidence
 
         true_label = 1 if entry.label == "HALLUCINATED" else 0
@@ -765,9 +759,9 @@ def auprc(
 ) -> float | None:
     """Compute Area Under Precision-Recall Curve for hallucination detection.
 
-    Same scoring convention as auroc(). Missing predictions and UNCERTAIN predictions
-    are excluded from the computation entirely (not assigned a neutral score of 0.5).
-    Returns None if no positive examples among the included entries.
+    Same scoring convention as auroc(). Missing, unevaluated, and UNCERTAIN
+    predictions are excluded from the computation entirely (not assigned a
+    neutral score of 0.5). Returns None if no positive examples remain.
 
     Args:
         entries: Benchmark entries (ground truth).
@@ -787,10 +781,11 @@ def auprc(
     for entry in entries:
         pred = predictions.get(entry.bibtex_key)
 
-        # Skip missing predictions and UNCERTAIN (no reliable score available)
-        if pred is None or pred.label == "UNCERTAIN":
+        # Skip missing, unevaluated, and UNCERTAIN predictions.
+        if not is_answer(pred):
             continue
 
+        assert pred is not None
         score = pred.confidence if pred.label == "HALLUCINATED" else 1.0 - pred.confidence
 
         true_label = 1 if entry.label == "HALLUCINATED" else 0
@@ -1190,8 +1185,8 @@ def paired_bootstrap_test(
     H0: metric_A <= metric_B.
 
     When ``two_sided=True`` (default), the returned p-value is two-sided:
-    p = 2 * fraction of bootstrap resamples where delta (metric_A - metric_B) <= 0,
-    capped at 1.0. This tests whether the two tools differ in either direction.
+    p = 2 * the smaller bootstrap tail probability around zero, capped at 1.0.
+    This tests whether the two tools differ in either direction.
 
     When ``two_sided=False``, the p-value is one-sided: p = fraction of bootstrap
     resamples where delta <= 0. This tests the directional hypothesis that tool A
@@ -1208,8 +1203,8 @@ def paired_bootstrap_test(
         metric_fn: Function that takes (entries, predictions) and returns a scalar metric.
         n_bootstrap: Number of bootstrap resamples.
         seed: Random seed for reproducibility.
-        two_sided: If True (default), return a two-sided p-value (one-sided * 2, capped at 1.0).
-            If False, return the one-sided p-value directly.
+        two_sided: If True (default), double the smaller bootstrap tail probability,
+            capped at 1.0. If False, return the one-sided p-value directly.
 
     Returns:
         Tuple (observed_diff, p_value, effect_size_cohens_h).
@@ -1425,7 +1420,7 @@ def compute_persisted_cis(
     )
 
     # ECE is only meaningful with >2 distinct confidence values (matches evaluate()).
-    distinct_conf = len({p.confidence for p in predictions if p.label != "UNCERTAIN"})
+    distinct_conf = len({p.confidence for p in predictions if is_answer(p)})
     ece_ci: list[float] | None = list(all_cis["ece"]) if distinct_conf > 2 else None
 
     # FPR is undefined when the split has no valid entries.
@@ -2106,8 +2101,8 @@ def evaluate(
 
     Evaluation Protocol:
     - UNCERTAIN predictions are excluded from classification metrics (DR, FPR, F1, TW-F1).
-      They count toward coverage but not toward the confusion matrix.
-    - Missing predictions are treated as VALID (conservative default)
+      They count toward response coverage but not selective-prediction coverage.
+    - Missing and unevaluated predictions are excluded from classification metrics.
     - Pre-screening results (if any) are included in the tool's predictions
     - Incomplete evaluations (partial coverage) can be aggregated using Plackett-Luce
       ranking (see hallmark.evaluation.ranking module)
@@ -2121,8 +2116,8 @@ def evaluate(
         compute_ci: If True, compute bootstrap confidence intervals (requires numpy).
         n_bootstrap: Number of bootstrap resamples for CIs (default 10_000).
         ci_seed: Random seed for bootstrap CI computation (default 42).
-        strict: If True, raise ValueError when coverage < 1.0 (missing predictions).
-            Mirrors the CLI's ``--strict`` flag.
+        strict: If True, raise ValueError when response coverage < 1.0 (missing
+            or unevaluated predictions). Mirrors the CLI's ``--strict`` flag.
         eval_mode: Controls how UNCERTAIN predictions and missing entries are handled.
             - ``"conservative"`` (default): UNCERTAIN excluded from classification metrics.
             - ``"aggressive"``: UNCERTAIN + missing predictions treated as HALLUCINATED
@@ -2229,16 +2224,19 @@ def evaluate(
     # F-7: Use intersection of entry_keys and pred_keys so that extra predictions
     # (keys not in entries) do not push coverage above 1.0.
     #
-    # ``response_coverage`` is the old meaning — did the tool return a record at
-    # all — and it is what strict mode checks, because a missing prediction and
-    # an abstention are different failures.
-    response_coverage = len(entry_keys & pred_keys) / len(entries) if entries else 1.0
+    # ``response_coverage`` is the weaker meaning — did the tool return a record
+    # backed by a real evaluation? UNCERTAIN counts because the tool did respond;
+    # ``evaluated=False`` does not because the record was manufactured.
+    response_keys = {
+        key for key in (entry_keys & pred_keys) if getattr(pred_map[key], "evaluated", True)
+    }
+    response_coverage = len(response_keys) / len(entries) if entries else 1.0
 
     if strict and response_coverage < 1.0:
-        missing = len(entries) - len(entry_keys & pred_keys)
+        missing = len(entries) - len(response_keys)
         raise ValueError(
             f"Strict mode: coverage is {response_coverage:.1%} (expected 100%). "
-            f"Missing predictions for {missing} entries."
+            f"Missing or unevaluated predictions for {missing} entries."
         )
 
     # ``coverage`` is selective-prediction coverage: the fraction of entries the
@@ -2248,7 +2246,7 @@ def evaluate(
     # committed run answers 68 of 500 entries and reported coverage 1.0. With
     # this definition ``coverage_adjusted_f1`` penalises abstention as
     # ``EvaluationResult.coverage_adjusted_f1`` has always documented.
-    answered_keys = {key for key in (entry_keys & pred_keys) if pred_map[key].label != "UNCERTAIN"}
+    answered_keys = {key for key in (entry_keys & pred_keys) if is_answer(pred_map[key])}
     coverage = len(answered_keys) / len(entries) if entries else 1.0
 
     cm = build_confusion_matrix(entries, pred_map)
@@ -2279,7 +2277,7 @@ def evaluate(
     cost = cost_efficiency(predictions)
     ece_score: float | None = expected_calibration_error(entries, pred_map, adaptive=True)
     # ECE is unreliable with ≤2 distinct confidence values (binary tools with 0.0/1.0 only)
-    distinct_confidences = len(set(p.confidence for p in predictions if p.label != "UNCERTAIN"))
+    distinct_confidences = len({p.confidence for p in predictions if is_answer(p)})
     if distinct_confidences <= 2:
         ece_score = None  # suppress unreliable ECE
     auroc_score = auroc(entries, pred_map)
@@ -2369,6 +2367,7 @@ def evaluate(
 
     pred_list: list[Prediction] = list(predictions)
     n_evaluated = evaluated_count(pred_list)
+    num_error_fallbacks = sum(1 for pred in pred_list if is_error_fallback(pred))
     if run_evaluated_nothing(pred_list):
         # Every prediction was manufactured because the tool never ran. The
         # rates below are all 0.0 and they are artefacts of that, not findings.
@@ -2383,14 +2382,21 @@ def evaluate(
             split_name,
             len(entries),
         )
-    elif n_evaluated < len(pred_list):
+    if n_evaluated < len(pred_list) or num_error_fallbacks > 0:
+        incomplete_mechanisms = []
+        if n_evaluated < len(pred_list):
+            num_unevaluated = len(pred_list) - n_evaluated
+            record_word = "record" if num_unevaluated == 1 else "records"
+            incomplete_mechanisms.append(f"{num_unevaluated} {record_word} marked evaluated=False")
+        if num_error_fallbacks > 0:
+            record_word = "record" if num_error_fallbacks == 1 else "records"
+            incomplete_mechanisms.append(f"{num_error_fallbacks} [Error fallback] {record_word}")
         logger.warning(
-            "%s on %s evaluated %d of %d predictions; the remainder are fallbacks "
-            "and are not evidence about those entries.",
+            "%s on %s has an incomplete evaluation: %s. These records are not "
+            "evidence about their entries.",
             tool_name,
             split_name,
-            n_evaluated,
-            len(pred_list),
+            "; ".join(incomplete_mechanisms),
         )
 
     return EvaluationResult(
@@ -2398,6 +2404,7 @@ def evaluate(
         split_name=split_name,
         num_entries=len(entries),
         num_evaluated=n_evaluated,
+        num_error_fallbacks=num_error_fallbacks,
         num_hallucinated=num_hallucinated,
         num_valid=num_valid,
         detection_rate=cm.detection_rate,

--- a/hallmark/evaluation/metrics.py
+++ b/hallmark/evaluation/metrics.py
@@ -983,6 +983,9 @@ def stratified_bootstrap_ci(
     Stratification ensures each bootstrap resample maintains the original
     proportion of each hallucination type, preventing bias from underrepresented types.
 
+    Missing and unevaluated predictions are excluded before resampling, so the
+    interval describes the same answered population as the point estimate.
+
     Args:
         entries: Benchmark entries (ground truth).
         predictions: Tool's predictions.
@@ -1008,22 +1011,12 @@ def stratified_bootstrap_ci(
     pred_map = {p.bibtex_key: p for p in predictions}
 
     for entry in entries:
-        h_type = entry.hallucination_type or "valid"
-        # Include all entries (not just those with predictions) so CIs reflect
-        # uncertainty from missing predictions, consistent with build_confusion_matrix.
         pred = pred_map.get(entry.bibtex_key)
+        if pred is None or not is_answer(pred):
+            continue
+        h_type = entry.hallucination_type or "valid"
         type_groups[h_type][0].append(entry)
-        if pred is not None:
-            type_groups[h_type][1].append(pred)
-        else:
-            # Missing prediction → treated as VALID with default confidence
-            type_groups[h_type][1].append(
-                Prediction(
-                    bibtex_key=entry.bibtex_key,
-                    label="VALID",
-                    confidence=0.5,
-                )
-            )
+        type_groups[h_type][1].append(pred)
 
     # Bootstrap resampling
     bootstrap_metrics = []
@@ -1072,8 +1065,7 @@ def _bootstrap_all_cis(
     because it reuses each bootstrap resample for all metrics.
 
     Stratification is by hallucination type, matching ``stratified_bootstrap_ci``.
-    Missing predictions are filled with VALID/0.5 placeholders, consistent with
-    ``build_confusion_matrix``.
+    Missing and unevaluated predictions are excluded, matching the point estimates.
 
     Args:
         entries: Benchmark entries (ground truth).
@@ -1102,15 +1094,12 @@ def _bootstrap_all_cis(
     pred_map = {p.bibtex_key: p for p in predictions}
 
     for entry in entries:
-        h_type = entry.hallucination_type or "valid"
         pred = pred_map.get(entry.bibtex_key)
+        if pred is None or not is_answer(pred):
+            continue
+        h_type = entry.hallucination_type or "valid"
         type_groups[h_type][0].append(entry)
-        if pred is not None:
-            type_groups[h_type][1].append(pred)
-        else:
-            type_groups[h_type][1].append(
-                Prediction(bibtex_key=entry.bibtex_key, label="VALID", confidence=0.5)
-            )
+        type_groups[h_type][1].append(pred)
 
     # Per-metric accumulators
     dr_samples: list[float] = []
@@ -1230,14 +1219,27 @@ def paired_bootstrap_test(
 
     # Group entries (and corresponding paired predictions) by hallucination type for
     # stratified resampling — same grouping logic as stratified_bootstrap_ci().
+    #
+    # Both tools must keep an entry in the same position, so an entry one tool
+    # did not answer stays in the group with a placeholder rather than being
+    # dropped: ``metric_fn`` and ``build_confusion_matrix`` index entries and
+    # predictions positionally. The placeholder carries ``evaluated=False`` so
+    # each tool skips its own non-answers exactly as standalone ``evaluate``
+    # does, while the pairing stays intact.
     type_groups: dict[str, list[tuple[BenchmarkEntry, Prediction, Prediction]]] = defaultdict(list)
     for entry in entries:
         h_type = entry.hallucination_type or "valid"
         pa = pred_map_a.get(entry.bibtex_key) or Prediction(
-            bibtex_key=entry.bibtex_key, label="VALID", confidence=0.5
+            bibtex_key=entry.bibtex_key,
+            label="VALID",
+            confidence=0.5,
+            evaluated=False,
         )
         pb = pred_map_b.get(entry.bibtex_key) or Prediction(
-            bibtex_key=entry.bibtex_key, label="VALID", confidence=0.5
+            bibtex_key=entry.bibtex_key,
+            label="VALID",
+            confidence=0.5,
+            evaluated=False,
         )
         type_groups[h_type].append((entry, pa, pb))
 
@@ -2014,6 +2016,13 @@ def _make_aggressive_predictions(
 
     - UNCERTAIN predictions → HALLUCINATED with confidence 0.55.
     - Missing keys → HALLUCINATED with confidence 0.55.
+
+    Aggressive mode is a scoring convention over the entry set, not a claim
+    about what the tool returned, so the synthesized records are answers and
+    score like any other prediction. ``evaluate`` measures coverage and the
+    evaluated count from the caller's own list, so these records never stand in
+    for a response the tool did not make.
+
     Does NOT mutate the caller's list or any Prediction object.
     """
     pred_map = {p.bibtex_key: p for p in predictions}
@@ -2028,8 +2037,7 @@ def _make_aggressive_predictions(
                     label="HALLUCINATED",
                     confidence=0.55,
                     reason="[aggressive mode: missing prediction treated as HALLUCINATED]",
-                    # The tool produced nothing for this entry.
-                    evaluated=False,
+                    evaluated=True,
                 )
             )
         elif pred.label == "UNCERTAIN":
@@ -2118,6 +2126,9 @@ def evaluate(
         ci_seed: Random seed for bootstrap CI computation (default 42).
         strict: If True, raise ValueError when response coverage < 1.0 (missing
             or unevaluated predictions). Mirrors the CLI's ``--strict`` flag.
+            Strict asks whether the tool answered every entry, which is
+            independent of the scoring convention, so it raises in aggressive
+            mode on the same runs it raises on in conservative mode.
         eval_mode: Controls how UNCERTAIN predictions and missing entries are handled.
             - ``"conservative"`` (default): UNCERTAIN excluded from classification metrics.
             - ``"aggressive"``: UNCERTAIN + missing predictions treated as HALLUCINATED
@@ -2167,6 +2178,14 @@ def evaluate(
         }
 
     # For aggressive mode, transform predictions locally — do NOT mutate caller's list.
+    #
+    # Coverage, the evaluated count and the partial-run warnings are measured
+    # from the caller's own list, kept here before the transform. Aggressive
+    # mode changes how an unanswered entry is scored, not how much of the split
+    # the tool responded to, so its synthesized records must not reach those
+    # counts.
+    original_predictions = list(predictions)
+    original_pred_map = {p.bibtex_key: p for p in original_predictions}
     if eval_mode == "aggressive":
         predictions = _make_aggressive_predictions(entries, predictions)
 
@@ -2227,8 +2246,11 @@ def evaluate(
     # ``response_coverage`` is the weaker meaning — did the tool return a record
     # backed by a real evaluation? UNCERTAIN counts because the tool did respond;
     # ``evaluated=False`` does not because the record was manufactured.
+    original_pred_keys = set(original_pred_map)
     response_keys = {
-        key for key in (entry_keys & pred_keys) if getattr(pred_map[key], "evaluated", True)
+        key
+        for key in (entry_keys & original_pred_keys)
+        if getattr(original_pred_map[key], "evaluated", True)
     }
     response_coverage = len(response_keys) / len(entries) if entries else 1.0
 
@@ -2246,7 +2268,9 @@ def evaluate(
     # committed run answers 68 of 500 entries and reported coverage 1.0. With
     # this definition ``coverage_adjusted_f1`` penalises abstention as
     # ``EvaluationResult.coverage_adjusted_f1`` has always documented.
-    answered_keys = {key for key in (entry_keys & pred_keys) if is_answer(pred_map[key])}
+    answered_keys = {
+        key for key in (entry_keys & original_pred_keys) if is_answer(original_pred_map[key])
+    }
     coverage = len(answered_keys) / len(entries) if entries else 1.0
 
     cm = build_confusion_matrix(entries, pred_map)
@@ -2365,7 +2389,7 @@ def evaluate(
     type_conf = type_confusion_matrix(entries, predictions)
     cascade_stats = cascade_breakdown(predictions)
 
-    pred_list: list[Prediction] = list(predictions)
+    pred_list = original_predictions
     n_evaluated = evaluated_count(pred_list)
     num_error_fallbacks = sum(1 for pred in pred_list if is_error_fallback(pred))
     if run_evaluated_nothing(pred_list):

--- a/tests/test_evaluated_flag_survives_rebuilds.py
+++ b/tests/test_evaluated_flag_survives_rebuilds.py
@@ -16,7 +16,11 @@ from hallmark.baselines.cascade import _aggressive_fallback
 from hallmark.baselines.common import fallback_predictions, run_with_prescreening
 from hallmark.baselines.prescreening import PreScreenResult, merge_with_predictions
 from hallmark.dataset.schema import BenchmarkEntry, BlindEntry, Prediction
-from hallmark.evaluation.metrics import _make_aggressive_predictions, run_evaluated_nothing
+from hallmark.evaluation.metrics import (
+    _make_aggressive_predictions,
+    evaluate,
+    run_evaluated_nothing,
+)
 
 
 def _blind(key: str) -> BlindEntry:
@@ -112,9 +116,26 @@ class TestAggressiveEvalModeKeepsTheFlag:
         assert all(p.label == "HALLUCINATED" for p in remapped)
         assert all(p.evaluated is False for p in remapped)
 
-    def test_a_missing_prediction_is_synthesised_as_unevaluated(self):
-        remapped = _make_aggressive_predictions(self._entries(), [])
-        assert all(p.evaluated is False for p in remapped)
+    def test_a_missing_prediction_is_synthesised_as_an_answer(self):
+        """The remap covers a prediction the tool made; a missing entry has none.
+
+        Aggressive mode scores an unanswered entry as HALLUCINATED by
+        convention, so its synthesized record has to be an answer or every
+        scoring site skips it and the mode collapses onto conservative.
+        ``evaluate`` measures coverage and the evaluated count from the caller's
+        own predictions, so the record still cannot pass for a response.
+        """
+        entries = self._entries()
+        remapped = _make_aggressive_predictions(entries, [])
+
+        assert all(p.label == "HALLUCINATED" for p in remapped)
+        assert all(p.evaluated is True for p in remapped)
+        assert all("aggressive mode" in p.reason for p in remapped)
+
+        result = evaluate(entries, [], eval_mode="aggressive")
+        assert result.detection_rate == 1.0
+        assert result.coverage == 0.0
+        assert result.num_evaluated == 0
 
 
 def test_both_variants_backfill_is_marked_unevaluated():

--- a/tests/test_metric_correctness_regressions.py
+++ b/tests/test_metric_correctness_regressions.py
@@ -91,6 +91,61 @@ def test_two_sided_p_value_is_high_for_identical_tools():
     assert p > 0.05
 
 
+def test_bootstrap_ci_contains_point_estimate_with_missing_predictions():
+    """A point estimate must lie inside its own published interval.
+
+    The bootstrap backfilled a missing prediction as VALID at confidence 0.5 and
+    scored it, while ``evaluate`` excludes it, so the two sides described
+    different populations: on this fixture the detection rate is 1.0 against an
+    interval around 0.25. Both sides now resample only the answered entries.
+    """
+    entries = _split(n_hall=40, n_valid=40)
+    predictions = [_pred(f"h{i}", "HALLUCINATED") for i in range(10)]
+    predictions += [_pred(f"v{i}", "VALID") for i in range(10)]
+
+    result = evaluate(entries, predictions, compute_ci=True, n_bootstrap=300, ci_seed=0)
+
+    assert result.detection_rate_ci is not None
+    dr_lower, dr_upper = result.detection_rate_ci
+    assert dr_lower <= result.detection_rate <= dr_upper, (
+        f"detection rate {result.detection_rate} outside its CI {result.detection_rate_ci}"
+    )
+
+    assert result.f1_hallucination_ci is not None
+    f1_lower, f1_upper = result.f1_hallucination_ci
+    assert f1_lower <= result.f1_hallucination <= f1_upper, (
+        f"F1 {result.f1_hallucination} outside its CI {result.f1_hallucination_ci}"
+    )
+
+
+def test_aggressive_mode_scores_missing_entries_without_claiming_coverage():
+    """Aggressive mode must score an unanswered entry and still report it unanswered.
+
+    The synthesized missing-entry records were stamped ``evaluated=False``, so
+    every scoring site skipped them and aggressive mode returned the
+    conservative numbers under the aggressive label. They are answers now, while
+    coverage, response coverage and the evaluated count are measured from the
+    caller's own predictions so the manufactured records do not inflate them.
+    """
+    entries = [
+        _entry("h1", "HALLUCINATED"),  # answered, and the tool got it wrong
+        _entry("h2", "HALLUCINATED"),  # no prediction
+        _entry("h3", "HALLUCINATED"),  # no prediction
+    ]
+    predictions = [_pred("h1", "VALID")]
+
+    cons = evaluate(entries, predictions, eval_mode="conservative")
+    aggr = evaluate(entries, predictions, eval_mode="aggressive")
+
+    assert cons.detection_rate == pytest.approx(0.0)
+    assert aggr.detection_rate == pytest.approx(2 / 3)
+    assert aggr.detection_rate != cons.detection_rate
+
+    assert aggr.coverage == cons.coverage == pytest.approx(1 / 3)
+    assert aggr.response_coverage == cons.response_coverage == pytest.approx(1 / 3)
+    assert aggr.num_evaluated == cons.num_evaluated == 1
+
+
 # --- 2. Per-type metrics need a real FPR denominator ---
 
 

--- a/tests/test_metric_correctness_regressions.py
+++ b/tests/test_metric_correctness_regressions.py
@@ -8,7 +8,11 @@ once you know what it replaced.
 
 from __future__ import annotations
 
-from hallmark.dataset.schema import BenchmarkEntry, Prediction
+import logging
+
+import pytest
+
+from hallmark.dataset.schema import BenchmarkEntry, EvaluationResult, Prediction
 from hallmark.evaluation.metrics import (
     _metric_f1,
     evaluate,
@@ -231,3 +235,102 @@ def test_strict_mode_still_keys_on_missing_predictions_not_abstention():
 
     result = evaluate(entries, preds, strict=True)  # must not raise
     assert result.coverage == 0.0
+
+
+# --- 5. Manufactured predictions are not answers ---
+
+
+def _partial_run_with_backfills():
+    entries = _split(n_hall=3, n_valid=3)
+    predictions = [
+        _pred("h0", "VALID", 0.9),
+        _pred("h1", "VALID", 0.8),
+        _pred("v0", "HALLUCINATED", 0.6),
+        Prediction(bibtex_key="h2", label="VALID", confidence=0.5, evaluated=False),
+        Prediction(bibtex_key="v1", label="VALID", confidence=0.5, evaluated=False),
+        Prediction(bibtex_key="v2", label="VALID", confidence=0.5, evaluated=False),
+    ]
+    return entries, predictions
+
+
+def test_unevaluated_backfills_reduce_both_coverage_measures():
+    entries, predictions = _partial_run_with_backfills()
+
+    result = evaluate(entries, predictions)
+
+    assert result.coverage == 0.5
+    assert result.response_coverage == 0.5
+
+
+def test_unevaluated_backfills_do_not_affect_scored_metrics():
+    entries, predictions = _partial_run_with_backfills()
+
+    result = evaluate(entries, predictions)
+
+    assert result.false_positive_rate == 1.0
+    assert result.ece == pytest.approx(0.7666666666666667)
+    assert result.auroc == 0.0
+    assert result.per_tier_metrics[1]["num_hallucinated"] == 2
+    assert result.per_tier_metrics[1]["num_valid"] == 1
+    assert result.per_type_metrics["fabricated_doi"]["count"] == 2
+    assert result.per_type_metrics["fabricated_doi"]["num_valid"] == 1
+
+
+def test_strict_mode_rejects_a_fully_unevaluated_backfill():
+    entries = _split(n_hall=2, n_valid=2)
+    predictions = [
+        Prediction(bibtex_key=e.bibtex_key, label="VALID", evaluated=False) for e in entries
+    ]
+
+    with pytest.raises(ValueError, match="Strict mode"):
+        evaluate(entries, predictions, strict=True)
+
+
+# --- 6. Legacy error fallbacks remain visible at run level ---
+
+
+def _run_with_error_fallbacks():
+    entries = _split(n_hall=2, n_valid=2)
+    predictions = [_pred(e.bibtex_key, e.label) for e in entries]
+    predictions[1].reason = "[Error fallback] API timeout"
+    return entries, predictions
+
+
+def test_error_fallbacks_are_counted_without_changing_num_evaluated():
+    entries, predictions = _run_with_error_fallbacks()
+
+    result = evaluate(entries, predictions)
+
+    assert result.num_evaluated == 4
+    assert result.num_error_fallbacks == 1
+
+
+def test_error_fallbacks_emit_an_incomplete_evaluation_warning(caplog):
+    entries, predictions = _run_with_error_fallbacks()
+
+    with caplog.at_level(logging.WARNING):
+        evaluate(entries, predictions, tool_name="legacy", split_name="fixture")
+
+    assert "1 [Error fallback] record" in caplog.text
+
+
+# --- 7. Legacy result files do not claim unrecorded response coverage ---
+
+
+def test_result_without_response_coverage_deserializes_as_not_recorded():
+    payload = {
+        "tool_name": "legacy",
+        "split_name": "fixture",
+        "num_entries": 4,
+        "num_hallucinated": 2,
+        "num_valid": 2,
+        "detection_rate": 0.5,
+        "false_positive_rate": 0.0,
+        "f1_hallucination": 0.5,
+        "tier_weighted_f1": 0.5,
+    }
+
+    result = EvaluationResult.from_dict(payload)
+
+    assert result.response_coverage is None
+    assert "response_coverage" in result.to_dict()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -89,9 +89,12 @@ class TestBuildConfusionMatrix:
             _entry("h1", "HALLUCINATED"),
         ]
         cm = build_confusion_matrix(entries, {})
-        # Missing predictions treated as VALID (conservative)
-        assert cm.tn == 1
-        assert cm.fn == 1
+        # An entry with no prediction is not an answer: it is skipped, not
+        # scored as VALID, so it can neither supply a true negative nor a miss.
+        assert cm.tn == 0
+        assert cm.fn == 0
+        assert cm.tp == 0
+        assert cm.fp == 0
 
     def test_mixed_results(self):
         entries = [
@@ -2024,7 +2027,7 @@ class TestEvaluateDualMode:
         assert aggr_fpr == pytest.approx(1.0)
 
     def test_evaluate_missing_predictions_aggressive(self):
-        """Missing keys: aggressive treats as HALLUCINATED, conservative as VALID."""
+        """Missing keys: aggressive treats as HALLUCINATED, conservative skips them."""
         entries = [
             _entry("v1", "VALID"),
             _entry("h1", "HALLUCINATED"),  # has prediction
@@ -2041,8 +2044,9 @@ class TestEvaluateDualMode:
         aggr = evaluate(
             entries, predictions, tool_name="t", split_name="dev", eval_mode="aggressive"
         )
-        # Conservative: h2 missing → treated as VALID (fn) → DR = 1/2 = 0.5
-        assert cons.detection_rate == pytest.approx(0.5)
+        # Conservative: h2 missing → not an answer, skipped → DR over the one
+        # answered hallucination = 1/1 = 1.0
+        assert cons.detection_rate == pytest.approx(1.0)
         # Aggressive: h2 missing → treated as HALLUCINATED → DR = 2/2 = 1.0
         assert aggr.detection_rate == pytest.approx(1.0)
         # Aggressive FPR: v1 predicted VALID → no FP, FPR = 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2029,14 +2029,12 @@ class TestEvaluateDualMode:
     def test_evaluate_missing_predictions_aggressive(self):
         """Missing keys: aggressive treats as HALLUCINATED, conservative skips them."""
         entries = [
-            _entry("v1", "VALID"),
-            _entry("h1", "HALLUCINATED"),  # has prediction
-            _entry("h2", "HALLUCINATED"),  # NO prediction
+            _entry("h1", "HALLUCINATED"),  # answered miss
+            _entry("h2", "HALLUCINATED"),  # no prediction
+            _entry("h3", "HALLUCINATED"),  # no prediction
         ]
         predictions = [
-            _pred("v1", "VALID"),
-            _pred("h1", "HALLUCINATED"),
-            # h2 intentionally missing
+            _pred("h1", "VALID"),
         ]
         cons = evaluate(
             entries, predictions, tool_name="t", split_name="dev", eval_mode="conservative"
@@ -2044,15 +2042,17 @@ class TestEvaluateDualMode:
         aggr = evaluate(
             entries, predictions, tool_name="t", split_name="dev", eval_mode="aggressive"
         )
-        # Conservative: h2 missing → not an answer, skipped → DR over the one
-        # answered hallucination = 1/1 = 1.0
-        assert cons.detection_rate == pytest.approx(1.0)
-        # Aggressive: h2 missing → treated as HALLUCINATED → DR = 2/2 = 1.0
-        assert aggr.detection_rate == pytest.approx(1.0)
-        # Aggressive FPR: v1 predicted VALID → no FP, FPR = 0
-        # Conservative FPR: same, = 0
-        assert cons.false_positive_rate == pytest.approx(0.0)
-        assert aggr.false_positive_rate == pytest.approx(0.0)
+        # Conservative: the two missing entries are skipped, so the answered
+        # miss is the only scored hallucination.
+        assert cons.detection_rate == pytest.approx(0.0)
+        # Aggressive: both missing entries are scored as detected hallucinations.
+        assert aggr.detection_rate == pytest.approx(2 / 3)
+        assert aggr.coverage == cons.coverage == pytest.approx(1 / 3)
+        assert aggr.response_coverage == cons.response_coverage == pytest.approx(1 / 3)
+        assert aggr.num_evaluated == cons.num_evaluated == 1
+
+        with pytest.raises(ValueError, match="Strict mode"):
+            evaluate(entries, predictions, strict=True, eval_mode="aggressive")
 
     def test_evaluate_conservative_default(self):
         """eval_mode defaults to 'conservative' and returns EvaluationResult."""


### PR DESCRIPTION
Findings H2-10 (CRITICAL), H1-5, H1-4 and two docstring items from the 2026-09-06 review, each reproduced by an independent verifier before the fix.

## What was wrong

- **Backfilled records scored as committed VALID verdicts.** Wrappers set `evaluated=False` on error-fallback and backfilled records, but nothing in `metrics.py` read it: the confusion matrix, `coverage`, ECE and AUROC filtered `UNCERTAIN` only. Verified end to end: 10 entries, 3 real predictions, 7 backfills → `num_evaluated=3`, `coverage=1.0`, `cm(tp=1, fp=0, tn=6, fn=3)`, FPR 0.0. Six of the true negatives were manufactured. An entry with no record at all was scored the same way.
- **`num_evaluated` counted error fallbacks as evaluations.** A 500-entry cross-domain run with 432 `[Error fallback]` records reported 500 of 500 evaluated with no warning; 9,573 such records sit under `results/`.
- **`response_coverage` defaulted to 1.0 on deserialisation**, so 41 of 44 committed results that predate the field read as having answered every entry (`bibtexupdater_dev_public.json` returned 1.0 against its own `coverage` 0.862).

## What changes

`is_answer(pred)` (not None, not `UNCERTAIN`, `evaluated` not False) gates every scoring site; a non-answer is skipped rather than counted as VALID, so "no record" and "manufactured record" score identically and strict mode counts an `evaluated=False` record as missing. `EvaluationResult.num_error_fallbacks` is filled from the marker and the incomplete-run warning names which mechanism fired. `response_coverage` defaults to `None` (not recorded). Two tests in `tests/test_metrics.py` that pinned missing-means-VALID are updated: an empty prediction set now yields an empty confusion matrix, and conservative detection rate is computed over the answered hallucinations.

**Published numbers:** DR, FPR and F1 of full-coverage runs are unchanged. Runs that contain error-fallback records (the DeepSeek-R1 cross-domain and test rows, among others) will report a lower coverage and metrics over the answered subset when regenerated, which is what the README's coverage caveat already says they should.

## Verification

Full suite 1460 passed / 17 skipped; ruff, ruff-format and `mypy --ignore-missing-imports hallmark/` clean via pre-commit. New regressions: N entries with k real predictions and N−k backfills give coverage k/N and FPR/ECE/AUROC over the k answered entries; `--strict` fails on a fully backfilled run; a fallback-carrying run sets `num_error_fallbacks` and warns; a legacy result deserialises with `response_coverage=None`. Diff produced by codex from the review specification (the two `test_metrics.py` updates by hand) and read before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
