### PR TITLE
The release guards cover what ships, and the dormant repair scripts are archived

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -56,6 +56,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The precomputed leg validates data/v1.2/baseline_results against its
+          # manifest, and the raw .jsonl results the manifest covers are LFS-tracked.
+          # Without the objects those files are pointer stubs and every checksum
+          # mismatches.
+          lfs: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           name: results-${{ matrix.baseline }}
           path: results/${{ matrix.baseline }}_${{ inputs.split || 'dev_public' }}.json
-          if-no-files-found: warn
+          if-no-files-found: error
 
   aggregate:
     name: Aggregate Results
@@ -140,19 +140,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: results-*
-          path: results/
+          path: run-results/
           merge-multiple: true
 
       - name: Generate leaderboard
         run: |
           python -m hallmark.cli leaderboard \
             --split ${{ inputs.split || 'dev_public' }} \
-            --results-dir results/
+            --results-dir run-results/
 
       - name: Append to history log
         run: |
           python -m hallmark.cli history-append \
-            --results-dir results/ \
+            --results-dir run-results/ \
             --output results/history.jsonl
 
       - name: Commit history update
@@ -167,7 +167,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: combined-results
-          path: results/
+          path: |
+            run-results/
+            results/history.jsonl
           if-no-files-found: warn
 
   gate:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,6 @@ jobs:
           ruff check .
           ruff format --check .
 
-      - name: Type check with mypy
-        run: mypy hallmark/ --ignore-missing-imports
-        continue-on-error: true
-
       - name: Check results freshness
         # Every aggregate result JSON must record the split revision it scored
         # (split_sha256) and agree with that split's current entry counts.
@@ -73,9 +69,24 @@ jobs:
       - name: Run tests
         run: pytest --tb=short -q --cov=hallmark --cov-report=term-missing
 
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run pinned mypy hook
+        run: |
+          python -m pip install pre-commit
+          pre-commit run mypy --all-files
+
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, type-check]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/data/v1.2/baseline_results/manifest.json
+++ b/data/v1.2/baseline_results/manifest.json
@@ -8,6 +8,12 @@
       "num_entries": 1119,
       "f1_hallucination": 0.8903993203058623
     },
+    "bibtexupdater_raw_dev_public.jsonl": {
+      "sha256": "bfa01ad369fe974829002fef0e9296da847efaee8d07556b3ff75eb639009e09"
+    },
+    "bibtexupdater_raw_supplement_chatgpt_citations.jsonl": {
+      "sha256": "39244a8fcbb8bc1ba08dd64eb7ff6f347e195954f207c6a61309f26080b95348"
+    },
     "bibtexupdater_test_public.json": {
       "sha256": "132b4d2fa383b8c2f359bb62e5c9ce6ab1f3f14ce233b88edb25293d9870e517",
       "baseline": "bibtexupdater",
@@ -302,6 +308,9 @@
       "split": "test_public",
       "num_entries": 831,
       "f1_hallucination": 0.7976291278577476
+    },
+    "llm_tool_augmented_dev_public.jsonl": {
+      "sha256": "2dd0c108966ae2fe74eea8fadd56d0837ad64e68ea7b4ba696c2d512df4244b0"
     },
     "llm_tool_augmented_test_public.json": {
       "sha256": "7d7733e0363906790592d11a953af83590024f0c54d7b56e290680dfa6a3e836",

--- a/hallmark/evaluation/validate.py
+++ b/hallmark/evaluation/validate.py
@@ -74,7 +74,8 @@ def validate_reference_results(
     Checks:
         1. manifest.json exists and is valid JSON
         2. All listed result files exist and checksums match
-        3. Each result JSON deserializes as a valid EvaluationResult
+        3. Each result JSON deserializes as a valid EvaluationResult; a raw
+           .jsonl output is checksummed and checked to be one JSON object per line
         4. num_entries matches dataset metadata (if metadata_path provided)
         5. (strict) Rejects F1=0.0 as likely failed run
 
@@ -102,9 +103,8 @@ def validate_reference_results(
 
     files: dict[str, dict] = manifest.get("files", {})
 
-    # Empty manifest is valid (placeholder state)
     if not files:
-        return ValidationResult(passed=True, warnings=["manifest has no files"])
+        return ValidationResult(passed=False, errors=["manifest has no files"])
 
     # Load metadata for cross-validation if provided
     metadata_splits: dict | None = None
@@ -133,6 +133,19 @@ def validate_reference_results(
                 f"{filename}: checksum mismatch "
                 f"(expected {expected_sha[:12]}..., got {actual_sha[:12]}...)"
             )
+            continue
+
+        # A released raw output (.jsonl) is one prediction per line, not an
+        # EvaluationResult: it is covered by the checksum above, and each line
+        # has to be a JSON object, nothing more.
+        if file_path.suffix == ".jsonl":
+            try:
+                with file_path.open() as fh:
+                    for lineno, line in enumerate(fh, start=1):
+                        if line.strip() and not isinstance(json.loads(line), dict):
+                            raise ValueError(f"line {lineno} is not a JSON object")
+            except (json.JSONDecodeError, ValueError, OSError) as e:
+                errors.append(f"{filename}: raw output is not one JSON object per line: {e}")
             continue
 
         # Deserializes as valid EvaluationResult?

--- a/scripts/archive/fix_data_quality_v1_2.py
+++ b/scripts/archive/fix_data_quality_v1_2.py
@@ -1,3 +1,4 @@
+# Archived; superseded by scripts/build_dataset.py.
 """
 Data quality fix script for HALLMARK benchmark data files.
 Runs all 5 tasks:

--- a/scripts/archive/fix_subtest_and_dedup.py
+++ b/scripts/archive/fix_subtest_and_dedup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Archived; superseded by scripts/build_dataset.py.
 """One-pass data quality fixes for HALLMARK benchmark splits.
 
 Tasks:

--- a/scripts/archive/patch_data_v1.py
+++ b/scripts/archive/patch_data_v1.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Archived; superseded by scripts/build_dataset.py.
 """Patch shipped data files to fix known quality issues.
 
 Fixes applied (idempotent — safe to run multiple times):

--- a/scripts/rebuild_results_manifest.py
+++ b/scripts/rebuild_results_manifest.py
@@ -74,7 +74,12 @@ def main() -> int:
         manifest = json.loads(manifest_path.read_text())
     manifest.setdefault("files", {})
 
-    present = sorted(p for p in args.results_dir.glob("*.json") if p.name != "manifest.json")
+    present = sorted(
+        path
+        for pattern in ("*.json", "*.jsonl")
+        for path in args.results_dir.glob(pattern)
+        if path.name != "manifest.json"
+    )
     before = set(manifest["files"])
     rebuilt: dict[str, Any] = {}
     for path in present:

--- a/scripts/rescore_btu_from_raw.py
+++ b/scripts/rescore_btu_from_raw.py
@@ -61,6 +61,11 @@ def main() -> int:
     ap.add_argument("--results-dir", type=Path, default=REPO_ROOT / "data/v1.2/baseline_results")
     ap.add_argument("--data-dir", type=Path, default=REPO_ROOT / "data")
     ap.add_argument("--version", default="v1.2")
+    ap.add_argument(
+        "--allow-unverified-raw",
+        action="store_true",
+        help="allow a raw file when the aggregate records no usable status histogram",
+    )
     ap.add_argument("--apply", action="store_true", help="write (default: dry run)")
     args = ap.parse_args()
 
@@ -76,6 +81,14 @@ def main() -> int:
 
     observed = status_histogram(args.raw)
     recorded = released.get("_btu_status_histogram")
+    if not recorded and not args.allow_unverified_raw:
+        print(
+            f"{target} records no usable _btu_status_histogram, so the raw file cannot "
+            "be verified as the run behind this aggregate. Pass --allow-unverified-raw "
+            "to accept that risk explicitly.",
+            file=sys.stderr,
+        )
+        return 1
     if recorded and observed != recorded:
         print(
             f"{args.raw} does not match the aggregate it would annotate.\n"
@@ -90,6 +103,14 @@ def main() -> int:
     split_file = args.data_dir / args.version / SPLIT_PATHS[args.split]
     entries = load_entries(split_file)
     predictions = _parse_jsonl_output(args.raw, 0.0, len(entries))
+    if len(predictions) != len(entries):
+        print(
+            f"{args.raw} contains {len(predictions)} parsed record(s), but {split_file} "
+            f"contains {len(entries)} scored entry(ies); refusing to derive coverage from "
+            "a partial raw output.",
+            file=sys.stderr,
+        )
+        return 1
     abstentions = sum(1 for p in predictions if p.label == "UNCERTAIN")
     answered = sum(1 for p in predictions if p.label != "UNCERTAIN")
     coverage = answered / len(entries)

--- a/scripts/rescore_btu_from_raw.py
+++ b/scripts/rescore_btu_from_raw.py
@@ -103,11 +103,19 @@ def main() -> int:
     split_file = args.data_dir / args.version / SPLIT_PATHS[args.split]
     entries = load_entries(split_file)
     predictions = _parse_jsonl_output(args.raw, 0.0, len(entries))
-    if len(predictions) != len(entries):
+    # The run behind the aggregate sizes this check, not the split. A bibtex-check
+    # run holds fewer records than the split has entries whenever it skipped an
+    # entry, and the aggregate's histogram counts exactly the records that run
+    # produced -- the released dev_public pair is 1112 records against 1119 entries,
+    # and coverage divides by the split size on purpose. Only where there is no
+    # histogram is the split size the one bound left.
+    expected = sum(recorded.values()) if recorded else len(entries)
+    reference = "the aggregate's status histogram" if recorded else str(split_file)
+    if len(predictions) != expected:
         print(
-            f"{args.raw} contains {len(predictions)} parsed record(s), but {split_file} "
-            f"contains {len(entries)} scored entry(ies); refusing to derive coverage from "
-            "a partial raw output.",
+            f"{args.raw} contains {len(predictions)} parsed record(s), but {reference} "
+            f"accounts for {expected}; refusing to derive coverage from a partial raw "
+            "output.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/verify_subtests.py
+++ b/scripts/verify_subtests.py
@@ -327,6 +327,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--max-structural",
+        type=int,
+        default=None,
+        help=(
+            "CI regression gate: exit non-zero if the structural violation count "
+            "exceeds this threshold. Track this separately from truth-table mismatches."
+        ),
+    )
+    parser.add_argument(
         "--data-root",
         type=Path,
         default=Path("."),
@@ -357,14 +366,23 @@ def main() -> int:
     else:
         print_report(report)
 
+    failed = False
     if args.max_mismatches is not None and report.num_mismatches > args.max_mismatches:
         print(
             f"\nFAIL: {report.num_mismatches} mismatches exceed the allowed "
             f"maximum of {args.max_mismatches}.",
             file=sys.stderr,
         )
-        return 1
-    return 0
+        failed = True
+    if args.max_structural is not None and report.num_structural > args.max_structural:
+        print(
+            f"\nFAIL: {report.num_structural} structural violations exceed the allowed "
+            f"maximum of {args.max_structural}. Repair with "
+            "`python scripts/fix_doi_resolves_na.py --apply`.",
+            file=sys.stderr,
+        )
+        failed = True
+    return int(failed)
 
 
 if __name__ == "__main__":

--- a/tests/test_released_raw_matches_its_aggregate.py
+++ b/tests/test_released_raw_matches_its_aggregate.py
@@ -16,12 +16,19 @@ file. It is the general form of the guard in
 from __future__ import annotations
 
 import collections
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
 RESULTS = Path(__file__).resolve().parent.parent / "data/v1.2/baseline_results"
+_RESCORE_SCRIPT = Path(__file__).resolve().parent.parent / "scripts/rescore_btu_from_raw.py"
+_spec = importlib.util.spec_from_file_location("rescore_btu_from_raw", _RESCORE_SCRIPT)
+assert _spec is not None and _spec.loader is not None
+rescore = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rescore)
 
 
 def _raw_aggregate_pairs() -> list[tuple[Path, Path]]:
@@ -66,3 +73,83 @@ def test_raw_output_describes_its_aggregate(raw: Path, aggregate: Path):
 def test_at_least_one_pair_is_checked():
     """Otherwise the parametrisation is empty and this file asserts nothing."""
     assert _raw_aggregate_pairs(), "no raw/aggregate pair found -- the guard is inert"
+
+
+@pytest.mark.parametrize(
+    "aggregate", sorted(RESULTS.glob("bibtexupdater_*.json")), ids=lambda p: p.name
+)
+def test_every_released_bibtexupdater_aggregate_has_a_status_histogram(aggregate: Path):
+    recorded = json.loads(aggregate.read_text()).get("_btu_status_histogram")
+    assert recorded, f"{aggregate.name} records no status histogram to verify raw output against"
+
+
+def _write_rescore_fixture(
+    tmp_path: Path, *, entries: int, recorded: object
+) -> tuple[Path, Path, Path]:
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    aggregate = {
+        "f1_hallucination": 0.5,
+        "coverage": 1.0,
+        "num_uncertain": 0,
+        "coverage_adjusted_f1": 0.5,
+    }
+    if recorded is not ...:
+        aggregate["_btu_status_histogram"] = recorded
+    (results_dir / "bibtexupdater_dev_public.json").write_text(json.dumps(aggregate))
+
+    data_dir = tmp_path / "data"
+    split = data_dir / "v1.2" / "dev_public.jsonl"
+    split.parent.mkdir(parents=True)
+    records = [
+        {
+            "bibtex_key": f"k{index}",
+            "bibtex_type": "article",
+            "fields": {"title": "T", "author": "A", "year": "2024"},
+            "label": "VALID",
+        }
+        for index in range(entries)
+    ]
+    split.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+    raw = tmp_path / "raw.jsonl"
+    raw.write_text('{"key":"k0","status":"verified"}\n')
+    return results_dir, data_dir, raw
+
+
+def _run_rescore(monkeypatch, results_dir: Path, data_dir: Path, raw: Path, *extra: str) -> int:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rescore_btu_from_raw.py",
+            "--split",
+            "dev_public",
+            "--raw",
+            str(raw),
+            "--results-dir",
+            str(results_dir),
+            "--data-dir",
+            str(data_dir),
+            *extra,
+        ],
+    )
+    return rescore.main()
+
+
+@pytest.mark.parametrize("recorded", [..., {}], ids=["missing", "empty"])
+def test_rescore_refuses_an_unverifiable_raw(monkeypatch, tmp_path, recorded):
+    results_dir, data_dir, raw = _write_rescore_fixture(tmp_path, entries=1, recorded=recorded)
+    assert _run_rescore(monkeypatch, results_dir, data_dir, raw) == 1
+
+
+def test_rescore_allows_explicit_unverified_raw_override(monkeypatch, tmp_path):
+    results_dir, data_dir, raw = _write_rescore_fixture(tmp_path, entries=1, recorded=...)
+    assert _run_rescore(monkeypatch, results_dir, data_dir, raw, "--allow-unverified-raw") == 0
+
+
+def test_rescore_refuses_a_partial_raw_output(monkeypatch, tmp_path):
+    results_dir, data_dir, raw = _write_rescore_fixture(
+        tmp_path, entries=2, recorded={"verified": 1}
+    )
+    assert _run_rescore(monkeypatch, results_dir, data_dir, raw) == 1

--- a/tests/test_released_raw_matches_its_aggregate.py
+++ b/tests/test_released_raw_matches_its_aggregate.py
@@ -149,7 +149,47 @@ def test_rescore_allows_explicit_unverified_raw_override(monkeypatch, tmp_path):
 
 
 def test_rescore_refuses_a_partial_raw_output(monkeypatch, tmp_path):
+    """With no histogram to size the run, the split size is the only bound left."""
+    results_dir, data_dir, raw = _write_rescore_fixture(tmp_path, entries=2, recorded=...)
+    assert _run_rescore(monkeypatch, results_dir, data_dir, raw, "--allow-unverified-raw") == 1
+
+
+def test_rescore_accepts_a_raw_shorter_than_its_split(monkeypatch, tmp_path):
+    """A run that skipped an entry is the normal case, and the histogram sizes it."""
     results_dir, data_dir, raw = _write_rescore_fixture(
         tmp_path, entries=2, recorded={"verified": 1}
     )
-    assert _run_rescore(monkeypatch, results_dir, data_dir, raw) == 1
+    assert _run_rescore(monkeypatch, results_dir, data_dir, raw) == 0
+
+
+def test_rescore_reproduces_the_released_coverage(monkeypatch, capsys):
+    """The script that regenerates a published number runs on the data it ships with.
+
+    The count guard sizes the raw file against the run rather than the split, and
+    the released pair is the case that separates the two: 1112 records against 1119
+    entries. No fixture stands in for it, because a guard sized to the split passes
+    every fixture in this file and refuses the release.
+    """
+    raw = RESULTS / "bibtexupdater_raw_dev_public.jsonl"
+    aggregate = RESULTS / "bibtexupdater_dev_public.json"
+    if not raw.is_file() or not aggregate.is_file():
+        pytest.skip("the released dev_public raw/aggregate pair is not present")
+    if raw.read_text(errors="ignore").startswith("version https://git-lfs"):
+        pytest.skip(f"{raw.name} is an unfetched LFS pointer")
+    released = json.loads(aggregate.read_text())
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rescore_btu_from_raw.py", "--split", "dev_public", "--raw", str(raw)],
+    )
+    assert rescore.main() == 0, "the released raw/aggregate pair no longer rescores"
+
+    printed = capsys.readouterr().out
+    recomputed = {
+        line.split()[0]: float(line.split("->")[1])
+        for line in (text.strip() for text in printed.splitlines())
+        if line.startswith(("coverage ", "num_uncertain "))
+    }
+    assert recomputed["coverage"] == pytest.approx(released["coverage"], abs=5e-5)
+    assert recomputed["num_uncertain"] == released["num_uncertain"]

--- a/tests/test_results_provenance.py
+++ b/tests/test_results_provenance.py
@@ -248,7 +248,7 @@ class TestBibtexCheckBinaryPinning:
         assert btu.resolve_bibtex_check_bin() == str(fake)
 
     def test_missing_pinned_binary_is_reported_not_silently_ignored(self, monkeypatch, tmp_path):
-        """Falling back to PATH would run a different build than the operator asked for."""
+        """An invalid explicit binary pin is reported as unresolvable."""
         from hallmark.baselines import bibtexupdater as btu
 
         monkeypatch.setenv(btu.BIBTEX_CHECK_BIN_ENV, str(tmp_path / "nope"))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 
 import pytest
 
 from hallmark.dataset.schema import EvaluationResult
 from hallmark.evaluation.validate import compute_sha256, validate_reference_results
 from scripts import rebuild_results_manifest as rebuild_manifest
+
+RELEASED_RESULTS = Path(__file__).resolve().parent.parent / "data/v1.2/baseline_results"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -229,6 +232,34 @@ class TestValidateReferenceResults:
         vr = validate_reference_results(tmp_path, metadata_path=meta_path)
         assert not vr.passed
         assert any("num_entries" in e for e in vr.errors)
+
+
+# ---------------------------------------------------------------------------
+# The released manifest against the released directory
+# ---------------------------------------------------------------------------
+
+
+def test_released_manifest_covers_every_released_result():
+    """A result the manifest omits is never checksummed, and the suite stays green.
+
+    Names only, never checksums, so this holds on a checkout that has not fetched
+    the LFS objects behind the raw .jsonl results.
+    """
+    manifest = json.loads((RELEASED_RESULTS / "manifest.json").read_text())
+    listed = set(manifest["files"])
+    on_disk = {
+        path.name
+        for pattern in ("*.json", "*.jsonl")
+        for path in RELEASED_RESULTS.glob(pattern)
+        if path.name != "manifest.json"
+    }
+    assert listed == on_disk, (
+        f"{RELEASED_RESULTS.name}/manifest.json no longer describes the directory it "
+        "ships with.\n"
+        f"  on disk, unlisted: {sorted(on_disk - listed)}\n"
+        f"  listed, absent   : {sorted(listed - on_disk)}\n"
+        "Repair with: python scripts/rebuild_results_manifest.py --apply"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 
 from hallmark.dataset.schema import EvaluationResult
 from hallmark.evaluation.validate import compute_sha256, validate_reference_results
+from scripts import rebuild_results_manifest as rebuild_manifest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -101,8 +103,57 @@ class TestValidateReferenceResults:
     def test_empty_manifest(self, tmp_path):
         (tmp_path / "manifest.json").write_text('{"files": {}}')
         vr = validate_reference_results(tmp_path)
-        assert vr.passed
-        assert any("no files" in w for w in vr.warnings)
+        assert not vr.passed
+        assert any("no files" in error for error in vr.errors)
+
+    def test_rebuild_manifest_covers_json_and_jsonl(self, monkeypatch, tmp_path):
+        (tmp_path / "manifest.json").write_text('{"files": {}}')
+        (tmp_path / "tool_dev_public.json").write_text("{}")
+        (tmp_path / "tool_raw_dev_public.jsonl").write_text('{"status": "verified"}\n')
+
+        monkeypatch.setattr(rebuild_manifest, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "rebuild_results_manifest.py",
+                "--results-dir",
+                str(tmp_path),
+                "--apply",
+            ],
+        )
+        assert rebuild_manifest.main() == 0
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        present = {
+            path.name
+            for pattern in ("*.json", "*.jsonl")
+            for path in tmp_path.glob(pattern)
+            if path.name != "manifest.json"
+        }
+        assert set(manifest["files"]) == present
+
+    def test_raw_jsonl_is_checksummed_not_deserialized(self, tmp_path):
+        """A released raw output is one prediction per line, not an EvaluationResult."""
+        result = _make_eval_result()
+        _write_result_and_manifest(tmp_path, result)
+        raw = tmp_path / "test_tool_dev_public.jsonl"
+        raw.write_text(
+            '{"bibtex_key": "a", "label": "VALID"}\n{"bibtex_key": "b", "label": "HALLUCINATED"}\n'
+        )
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        manifest["files"][raw.name] = {"sha256": compute_sha256(raw)}
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+        vr = validate_reference_results(tmp_path, strict=True)
+        assert vr.passed, vr.errors
+
+        raw.write_text('{"bibtex_key": "a"}\nnot json\n')
+        manifest["files"][raw.name] = {"sha256": compute_sha256(raw)}
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+        vr = validate_reference_results(tmp_path, strict=True)
+        assert not vr.passed
+        assert any("one JSON object per line" in e for e in vr.errors)
 
     def test_checksum_mismatch(self, tmp_path):
         result = _make_eval_result()

--- a/tests/test_verify_subtests.py
+++ b/tests/test_verify_subtests.py
@@ -55,6 +55,8 @@ _spec.loader.exec_module(vs)
 # a field, whose False is correct data against a True default.
 MAX_PUBLIC_MISMATCHES = 101
 MAX_HIDDEN_MISMATCHES = 42
+MAX_PUBLIC_STRUCTURAL = 0
+MAX_HIDDEN_STRUCTURAL = 0
 
 # A single total hid two different defects, because it was tuned to exactly the
 # splits CI can see. ``data/hidden/`` is gitignored, so a contributor's run and
@@ -124,6 +126,26 @@ class TestVerifyEntrySubtests:
         m = vs.verify_entry_subtests(entry)
         assert [x.subtest for x in m] == ["title_exists"]
         assert m[0].assigned is True and m[0].expected is False
+
+    def test_max_structural_cli_gate_is_independent(self, monkeypatch, tmp_path):
+        split = tmp_path / "data" / "v1.2" / "dev_public.jsonl"
+        split.parent.mkdir(parents=True)
+        split.write_text(
+            '{"bibtex_key":"k","label":"VALID","fields":{},"subtests":{"doi_resolves":false}}\n'
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "verify_subtests.py",
+                "--data-root",
+                str(tmp_path),
+                "--max-structural",
+                "0",
+            ],
+        )
+
+        assert vs.main() == 1
 
     def test_authors_match_mismatch_flagged(self):
         # placeholder_authors expects authors_match=False.
@@ -303,4 +325,23 @@ class TestSubtestConsistencyGate:
         assert hidden <= MAX_HIDDEN_MISMATCHES, (
             f"sub-test consistency regressed on the hidden split: {hidden} mismatches "
             f"> baseline {MAX_HIDDEN_MISMATCHES}. Ratchet DOWN only."
+        )
+
+    def test_public_structural_violations_within_baseline(self, report):
+        public = [m for m in report.structural if m.split != "test_hidden"]
+        assert len(public) <= MAX_PUBLIC_STRUCTURAL, (
+            f"structural sub-test consistency regressed on the public splits: "
+            f"{len(public)} violations > baseline {MAX_PUBLIC_STRUCTURAL}. Repair with "
+            "`python scripts/fix_doi_resolves_na.py --apply`."
+        )
+
+    def test_hidden_structural_violations_within_baseline(self, report):
+        if not (_REPO_ROOT / vs.DEFAULT_SPLITS["test_hidden"]).exists():
+            pytest.skip("hidden split not present — its structural bound was not checked")
+
+        hidden = [m for m in report.structural if m.split == "test_hidden"]
+        assert len(hidden) <= MAX_HIDDEN_STRUCTURAL, (
+            f"structural sub-test consistency regressed on the hidden split: "
+            f"{len(hidden)} violations > baseline {MAX_HIDDEN_STRUCTURAL}. Repair with "
+            "`python scripts/fix_doi_resolves_na.py --apply`."
         )


### PR DESCRIPTION
Release-guard package from the 2026-09-06 review (findings H3-3, H3-6, H3-7, H3-8, H3-10, H3-12, H3-14; decision DEC-9 taken as *archive, do not delete*).

## What was wrong, and what changes

- **Manifest.** `validate_reference_results` accepted an empty manifest, the manifest was maintained by hand, and the three released `.jsonl` raw outputs were outside it. Now: an empty manifest fails; `scripts/rebuild_results_manifest.py` covers `*.json` and `*.jsonl`; the validator checksums a `.jsonl` and checks it is one JSON object per line instead of deserialising it as an `EvaluationResult`. `data/v1.2/baseline_results/manifest.json` is rebuilt (45 files, 3 added, 0 checksum changes) and `hallmark validate-results --strict` passes.
- **Sub-test ratchet.** `scripts/verify_subtests.py` computed and printed the structural class but bounded it by nothing, so the `doi_resolves` defect v1.2.3 removed could return silently. It is now gated by `--max-structural`, with separate zero ratchets for the public and hidden populations.
- **Raw-versus-aggregate check.** `scripts/rescore_btu_from_raw.py` skipped the identity check whenever the aggregate carried no `_btu_status_histogram`, the one thing preventing a coverage figure from another run. It now fails on a missing or empty histogram and on a partial raw output; `--allow-unverified-raw` is the explicit override.
- **CI.** The baselines workflow's `history-append` wrote a row for every `*.json` under `results/`, including non-results, so 182 of the 214 committed history rows are all-null; rows now come only from the run's downloaded artifacts. mypy moves from a `continue-on-error` matrix step to a hard, non-matrix job using the pinned pre-commit hook. Per-baseline artifact upload uses `if-no-files-found: error`.
- **Dormant scripts.** `scripts/fix_data_quality.py`, `fix_subtest_and_dedup.py` and `patch_data_v1.py` pointed at the live released splits, were referenced by nothing, and one half-rewrote `dev_public` before crashing. Archived under `scripts/archive/` (the first as `fix_data_quality_v1_2.py`, since an older `fix_data_quality.py` already lived there), each with a header naming its type-aware, dry-run-by-default successor.

**Deferred for a ruling:** bringing `results/` (20 stale JSONs, the leaderboard's default directory) and `site/` under the freshness gate (DEC-8), and the 39 released results still carrying the superseded per-type definition (DEC-3).

## Verification

Full suite 1463 passed / 18 skipped; ruff, ruff-format, mypy clean via pre-commit; both workflow files parse. The behavioural regressions were checked against the pre-fix code (7 failed before the source changes). The two CI workflow edits are exercised only by the next baselines run, not locally. Diff produced by codex from the review specification; the `.jsonl` validator path, its test and the manifest rebuild by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
