### PR TITLE
The bibtex-check wrapper runs the tool once, maps every status, and refuses an outage under every exit code

### DIFF
--- a/hallmark/baselines/_cache.py
+++ b/hallmark/baselines/_cache.py
@@ -24,8 +24,19 @@ T = TypeVar("T")
 
 _DEFAULT_CACHE_DIR = Path.home() / ".cache" / "hallmark"
 
-# CLI flags whose *value* is a credential and must never reach a log file.
-_SECRET_FLAGS = frozenset({"--s2-api-key", "--api-key", "--openai-api-key", "--token"})
+# CLI flags whose *value* must never reach a log file: credentials, and the
+# contact addresses the polite-pool APIs ask for, which are personal data that
+# a committed log would publish.
+_SECRET_FLAGS = frozenset(
+    {
+        "--s2-api-key",
+        "--api-key",
+        "--openai-api-key",
+        "--token",
+        "--mailto",
+        "--openalex-mailto",
+    }
+)
 
 # Upper bound on a honoured ``Retry-After``. Servers occasionally answer with windows
 # of an hour or more; sleeping that long would stall an evaluation run, so we wait at

--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -55,7 +55,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -472,6 +472,13 @@ def parse_source_condition(output: str) -> dict[str, object] | None:
 
     Availability moves outcomes, so it belongs in the result beside the numbers
     rather than only in a log a reader never sees.
+
+    ``incomplete_fraction`` is derived from the two counts, not from the
+    percentage in the line. bibtex-check prints that percentage rounded to one
+    decimal while gating on the unrounded value, so 83 of 831 entries prints as
+    "10.0%" and is 0.0999 -- healthy by the tool's own 10% threshold. Reading
+    the printed number back would refuse a run the tool passed. The printed
+    value is kept as ``reported_fraction`` so the log line stays reconstructible.
     """
     # The final summary line wins: bibtex-check may report progressively.
     matches = list(_OUTAGE_RE.finditer(output))
@@ -487,12 +494,46 @@ def parse_source_condition(output: str) -> dict[str, object] | None:
                 per_source[name.strip()] = int(count.rstrip(")"))
             except ValueError:
                 continue
+    incomplete = int(match.group(1))
+    total = int(match.group(2))
     return {
-        "entries_with_incomplete_lookups": int(match.group(1)),
-        "entries_total": int(match.group(2)),
-        "incomplete_fraction": float(match.group(3)) / 100.0,
+        "entries_with_incomplete_lookups": incomplete,
+        "entries_total": total,
+        "incomplete_fraction": (incomplete / total) if total else 0.0,
+        "reported_fraction": float(match.group(3)) / 100.0,
         "per_source_failures": per_source,
     }
+
+
+def _cmd_flag_value(cmd: Sequence[str], flag: str) -> str | None:
+    """The value *cmd* actually passes for *flag*, or None if it passes none.
+
+    ``extra_args`` are appended after the wrapper's own flags and argparse takes
+    the last occurrence, so a caller can override a setting the wrapper thinks
+    it chose. Provenance has to read the assembled command rather than the
+    constants it was built from. Both ``--flag value`` and ``--flag=value``
+    count, since argparse accepts both.
+    """
+    value: str | None = None
+    prefix = f"{flag}="
+    for index, part in enumerate(cmd):
+        if part == flag:
+            if index + 1 < len(cmd):
+                value = cmd[index + 1]
+        elif part.startswith(prefix):
+            value = part[len(prefix) :]
+    return value
+
+
+def _cmd_flag_int(cmd: Sequence[str], flag: str, default: int) -> int:
+    """``_cmd_flag_value`` as an integer, falling back to *default* when unreadable."""
+    raw = _cmd_flag_value(cmd, flag)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
 
 
 def resolve_bibtex_check_rate_limit(default: int) -> int:
@@ -889,7 +930,6 @@ def _run_bibtex_check_subprocess(
         binary = binary or "bibtex-check"
         rate_limit = resolve_bibtex_check_rate_limit(rate_limit)
         mailto = os.environ.get(BIBTEX_CHECK_MAILTO_ENV, "").strip()
-        mailto_domain = mailto.rpartition("@")[2] or None
         # Say which build is answering. Without this the run is silent about the
         # single fact that decides whether its numbers are comparable to any
         # other run's, and PATH may be resolving an editable install.
@@ -930,12 +970,10 @@ def _run_bibtex_check_subprocess(
         if extra_args:
             cmd.extend(extra_args)
 
-        # Run bibtex-check. API keys are masked by ``redact_command``; mailto is
-        # masked here because the shared secret-flag table is outside this package.
-        logged_cmd = list(cmd)
-        if mailto:
-            logged_cmd[logged_cmd.index("--mailto") + 1] = "***"
-        logger.info("Running: %s", redact_command(logged_cmd))
+        # API keys and the contact address are masked by ``redact_command``,
+        # which reads ``_SECRET_FLAGS`` and covers every spelling and every
+        # occurrence -- including a flag that arrived through ``extra_args``.
+        logger.info("Running: %s", redact_command(cmd))
         timed_out = False
         try:
             result = subprocess.run(
@@ -961,12 +999,16 @@ def _run_bibtex_check_subprocess(
                             if isinstance(source, str):
                                 per_source_failures[source] = per_source_failures.get(source, 0) + 1
                 parsed_condition["per_source_failures"] = per_source_failures
+            # Read the settings back off the command that ran. ``extra_args``
+            # may override any of them, and a stamp that records the wrapper's
+            # constants instead would describe a run that did not happen.
+            ran_mailto = (_cmd_flag_value(cmd, "--mailto") or "").strip()
             condition = {
                 **(parsed_condition or {}),
-                "rate_limit": rate_limit,
-                "workers": BIBTEX_CHECK_WORKERS,
-                "mailto_configured": bool(mailto),
-                "mailto_domain": mailto_domain,
+                "rate_limit": _cmd_flag_int(cmd, "--rate-limit", rate_limit),
+                "workers": _cmd_flag_int(cmd, "--workers", BIBTEX_CHECK_WORKERS),
+                "mailto_configured": bool(ran_mailto),
+                "mailto_domain": ran_mailto.rpartition("@")[2] or None,
             }
             _last_source_condition = condition
             if result.returncode == 0 and result.stderr.strip():
@@ -983,7 +1025,9 @@ def _run_bibtex_check_subprocess(
             )
             # bibtex-check prints its source report below the threshold too, so
             # the report's presence proves nothing; the fraction it carries does.
-            # A strict-mode exit 4 is an outage exactly when that fraction says so.
+            # A strict-mode exit 4 is an outage exactly when that fraction says
+            # so. The fraction is the one computed from the report's counts, so
+            # the wrapper and the tool gate on the same number.
             is_source_outage = (
                 result.returncode == EXIT_SOURCE_OUTAGE
                 or incomplete_fraction >= SOURCE_OUTAGE_THRESHOLD

--- a/hallmark/baselines/bibtexupdater.py
+++ b/hallmark/baselines/bibtexupdater.py
@@ -65,6 +65,10 @@ from hallmark.dataset.schema import BlindEntry, Prediction
 
 logger = logging.getLogger(__name__)
 
+# Unmapped statuses seen in this process, so a drifted tool vocabulary emits
+# one operator warning per status rather than one per record.
+_WARNED_UNMAPPED_STATUSES: set[str] = set()
+
 
 class SourceOutageError(RuntimeError):
     """bibtex-check reported that its sources went dark during the run.
@@ -91,7 +95,6 @@ STATUS_TO_LABEL: dict[str, str] = {
     "hallucinated": "HALLUCINATED",
     "api_error": "VALID",  # Conservative: don't flag on errors
     "network_error": "VALID",  # Lookup never reached a source: abstention, not evidence
-    "coverage_incomplete": "VALID",  # Sources throttled/errored: abstention, not evidence
     # bibtex-updater >=1.2.0 statuses
     "unconfirmed": "VALID",  # Abstention (could-not-verify): conservative VALID
     "given_name_substitution": "HALLUCINATED",  # Co-author given name is a different person
@@ -121,6 +124,7 @@ STATUS_TO_LABEL: dict[str, str] = {
     "working_paper_verified": "VALID",
     "working_paper_not_found": "HALLUCINATED",
     # General
+    "parse_error": "VALID",  # Parser failure: abstention, not evidence
     "skipped": "VALID",  # Conservative
 }
 
@@ -145,6 +149,7 @@ ABSTENTION_STATUSES: frozenset[str] = frozenset(
         "api_error",
         "network_error",
         "coverage_incomplete",
+        "parse_error",
         "skipped",
         "strict_warn_preprint_year",
         "strict_warn_cnv",
@@ -163,6 +168,7 @@ ABSTENTION_REASONS: dict[str, str] = {
     "api_error": "the source lookup failed (API error)",
     "network_error": "the source lookup failed (network error)",
     "coverage_incomplete": "the lookup did not complete against every source",
+    "parse_error": "bibtex-check could not read this entry",
     "skipped": "bibtex-check does not verify this entry type",
     "strict_warn_preprint_year": (
         "strict mode flagged a preprint-year discrepancy and left the decision to the user"
@@ -217,6 +223,7 @@ STATUS_TO_CONFIDENCE: dict[str, float] = {
     "book_not_found": 0.75,
     "working_paper_verified": 0.85,
     "working_paper_not_found": 0.70,
+    "parse_error": 0.50,
     "skipped": 0.50,
 }
 
@@ -343,6 +350,7 @@ class BatchHealth:
 def assess_batch_health(
     statuses: Iterable[str],
     *,
+    coverage_flags: Iterable[bool] | None = None,
     threshold: float = NOT_FOUND_SHARE_THRESHOLD,
     min_batch_size: int = MIN_BATCH_FOR_HEALTH_CHECK,
 ) -> BatchHealth:
@@ -351,6 +359,8 @@ def assess_batch_health(
     Args:
         statuses: Raw per-entry status strings, e.g. the values of the dict
             returned by ``run_bibtex_check_with_status``.
+        coverage_flags: Per-entry ``coverage_incomplete`` values from the raw
+            records, aligned with ``statuses``.
         threshold: No-evidence share above which the batch is suspect.
         min_batch_size: Smallest batch on which the share is evaluated.
 
@@ -359,11 +369,25 @@ def assess_batch_health(
         caller gates checkpointing on.
     """
     status_list = list(statuses)
+    flag_list = list(coverage_flags or ())
+    flag_list.extend([False] * (len(status_list) - len(flag_list)))
+    coverage_incomplete = [
+        flag or status in COVERAGE_INCOMPLETE_STATUSES
+        for status, flag in zip(status_list, flag_list, strict=False)
+    ]
     return BatchHealth(
         total=len(status_list),
-        not_found=sum(1 for s in status_list if s == "not_found"),
-        transport_error=sum(1 for s in status_list if s in TRANSPORT_FAILURE_STATUSES),
-        coverage_incomplete=sum(1 for s in status_list if s in COVERAGE_INCOMPLETE_STATUSES),
+        not_found=sum(
+            1
+            for status, incomplete in zip(status_list, coverage_incomplete, strict=False)
+            if status == "not_found" and not incomplete
+        ),
+        transport_error=sum(
+            1
+            for status, incomplete in zip(status_list, coverage_incomplete, strict=False)
+            if status in TRANSPORT_FAILURE_STATUSES and not incomplete
+        ),
+        coverage_incomplete=sum(coverage_incomplete),
         threshold=threshold,
         min_batch_size=min_batch_size,
     )
@@ -394,6 +418,8 @@ BIBTEX_CHECK_BIN_ENV = "HALLMARK_BIBTEX_CHECK_BIN"
 #: Pacing is therefore part of the run condition and belongs on the same
 #: footing as the binary: settable, and recorded in the log.
 BIBTEX_CHECK_RATE_ENV = "HALLMARK_BIBTEX_CHECK_RATE_LIMIT"
+BIBTEX_CHECK_MAILTO_ENV = "BIBTEX_CHECK_MAILTO"
+BIBTEX_CHECK_WORKERS = 8
 
 #: bibtex-check's exit code for "sources went dark during this run".
 #:
@@ -409,6 +435,7 @@ BIBTEX_CHECK_RATE_ENV = "HALLMARK_BIBTEX_CHECK_RATE_LIMIT"
 #: entries' abstentions carry no information -- and nothing downstream could
 #: tell them from real ones.
 EXIT_SOURCE_OUTAGE = 5
+SOURCE_OUTAGE_THRESHOLD = 0.10
 
 #: Set to "1" to score a run bibtex-check reported as a source outage anyway.
 #: Deliberately awkward: the numbers are not comparable to a healthy run.
@@ -422,19 +449,22 @@ _OUTAGE_RE = re.compile(
 )
 
 
-#: The source-availability report of the most recent bibtex-check run in this
-#: process, or None when it reported none. Set by ``_run_bibtex_check_subprocess``
-#: on every run -- exit 0 included, since bibtex-check prints the same summary
-#: below its 10% threshold -- and copied onto the EvaluationResult by the CLI's
-#: provenance stamp. Before this the report was parsed only to format one log
-#: line, so a run scored under HALLMARK_ALLOW_SOURCE_OUTAGE=1 carried no record
-#: of which sources were dark.
+#: The source-availability and invocation settings of the most recent
+#: bibtex-check run in this process, or None before a process started. Set by
+#: ``_run_bibtex_check_subprocess`` on every run and copied onto the
+#: EvaluationResult by the CLI's provenance stamp.
 _last_source_condition: dict[str, object] | None = None
+_ran_bibtex_check = False
 
 
 def last_source_condition() -> dict[str, object] | None:
-    """The source-availability report of the last bibtex-check run, if any."""
+    """The source availability and settings of the last bibtex-check run."""
     return _last_source_condition
+
+
+def ran_bibtex_check() -> bool:
+    """Whether the most recent wrapper call started ``bibtex-check``."""
+    return _ran_bibtex_check
 
 
 def parse_source_condition(output: str) -> dict[str, object] | None:
@@ -466,7 +496,10 @@ def parse_source_condition(output: str) -> dict[str, object] | None:
 
 
 def resolve_bibtex_check_rate_limit(default: int) -> int:
-    """Per-service request rate for this run, from the environment or *default*."""
+    """``--rate-limit`` scale for this run, from the environment or *default*.
+
+    bibtex-check interprets 45 as scale 1.0 and derives separate service budgets.
+    """
     raw = os.environ.get(BIBTEX_CHECK_RATE_ENV)
     if not raw:
         return default
@@ -522,10 +555,29 @@ def bibtex_check_version(binary: str | None = None) -> str | None:
     binary = binary or resolve_bibtex_check_bin()
     if not binary:
         return None
-    python = Path(binary).with_name("python")
-    if not python.exists():
-        python = Path(binary).with_name("python3")
-    if not python.exists():
+    requested_binary = binary
+    resolved_binary = Path(os.path.realpath(binary))
+    python: Path | None = None
+    try:
+        with open(resolved_binary) as script:
+            first_line = script.readline().strip()
+        if first_line.startswith("#!"):
+            interpreter = first_line.removeprefix("#!").strip().split()
+            if interpreter:
+                candidate = Path(interpreter[0])
+                if candidate.exists():
+                    python = candidate
+    except (OSError, UnicodeError):
+        pass
+
+    if python is None:
+        for name in ("python", "python3"):
+            candidate = resolved_binary.with_name(name)
+            if candidate.exists():
+                python = candidate
+                break
+    if python is None:
+        logger.warning("Could not find bibtex-check's interpreter for %s", requested_binary)
         return None
     try:
         out = subprocess.run(
@@ -534,10 +586,12 @@ def bibtex_check_version(binary: str | None = None) -> str | None:
             text=True,
             timeout=30,
         )
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Could not probe bibtex-check version for %s: %s", requested_binary, exc)
         return None
     lines = [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
-    if not lines:
+    if out.returncode != 0 or not lines:
+        logger.warning("Could not probe bibtex-check version for %s", requested_binary)
         return None
     source_version = lines[0]
     metadata_version = lines[1] if len(lines) > 1 else None
@@ -593,6 +647,7 @@ def run_bibtex_check_with_status(
     rate_limit: int = 120,
     academic_only: bool = True,
     skip_prescreening: bool = False,
+    _health_out: list[BatchHealth] | None = None,
     **_kw: object,
 ) -> tuple[list[Prediction], dict[str, str]]:
     """Run bibtex-check and return both predictions and raw per-entry status strings.
@@ -680,13 +735,18 @@ def run_bibtex_check_with_status(
 
     # Step 1: Run the subprocess on all entries to get raw tool predictions.
     # The reason string encodes the raw status as "Status: <status>[; ...]".
-    tool_predictions = _run_bibtex_check_subprocess(
+    subprocess_output = _run_bibtex_check_subprocess(
         entries,
         extra_args=extra_args,
         timeout=timeout,
         rate_limit=rate_limit,
         academic_only=academic_only,
     )
+    if isinstance(subprocess_output, tuple):
+        tool_predictions, raw_records = subprocess_output
+    else:
+        tool_predictions = subprocess_output
+        raw_records = []
 
     # Step 2: Extract raw status from each tool prediction's reason string.
     tool_key_to_status: dict[str, str] = {}
@@ -702,20 +762,12 @@ def run_bibtex_check_with_status(
     tool_key_set = {p.bibtex_key for p in tool_predictions}
     missing_keys: set[str] = {e.bibtex_key for e in entries} - tool_key_set
 
-    # Step 4: Obtain the final merged predictions via run_with_prescreening,
-    # which handles backfill and pre-screening merge in one pass.
-    def _run_tool(tool_entries: list[BlindEntry]) -> list[Prediction]:
-        return _run_bibtex_check_subprocess(
-            tool_entries,
-            extra_args=extra_args,
-            timeout=timeout,
-            rate_limit=rate_limit,
-            academic_only=academic_only,
-        )
-
+    # Step 4: Apply backfill and pre-screening to the predictions already in
+    # hand. ``run_with_prescreening`` may append backfills to the runner's list,
+    # so return a copy to preserve the raw tool results used below.
     final_predictions = run_with_prescreening(
         entries,
-        _run_tool,
+        lambda _entries: list(tool_predictions),
         skip_prescreening=skip_prescreening,
         backfill_reason="Entry not in bibtex-check output",
     )
@@ -746,9 +798,17 @@ def run_bibtex_check_with_status(
     # broken lookup path, not a bibliography of invented papers — say so loudly
     # so an operator watching the log can kill the run before it burns Stage 2
     # budget on entries no database was ever asked about.
-    health = assess_batch_health(status_dict.values())
+    raw_by_key = {record.get("key", ""): record for record in raw_records}
+    coverage_flags = [
+        raw_by_key.get(key, {}).get("coverage_incomplete") is True for key in all_keys
+    ]
+    health = assess_batch_health(
+        (status_dict[key] for key in all_keys), coverage_flags=coverage_flags
+    )
     if health.suspected_transport_failure:
         logger.warning(health.warning_message())
+    if _health_out is not None:
+        _health_out.append(health)
 
     return final_predictions, status_dict
 
@@ -781,6 +841,7 @@ def run_bibtex_check_with_health(
     Returns:
         A 3-tuple ``(predictions, status_dict, health)``.
     """
+    health_out: list[BatchHealth] = []
     predictions, status_dict = run_bibtex_check_with_status(
         entries,
         extra_args=extra_args,
@@ -788,8 +849,9 @@ def run_bibtex_check_with_health(
         rate_limit=rate_limit,
         academic_only=academic_only,
         skip_prescreening=skip_prescreening,
+        _health_out=health_out,
     )
-    return predictions, status_dict, assess_batch_health(status_dict.values())
+    return predictions, status_dict, health_out[0]
 
 
 def _run_bibtex_check_subprocess(
@@ -798,11 +860,13 @@ def _run_bibtex_check_subprocess(
     timeout: float = 7200.0,
     rate_limit: int = 120,
     academic_only: bool = True,
-) -> list[Prediction]:
-    """Run bibtex-check subprocess and return raw predictions (no pre-screening)."""
-    global _last_source_condition
+) -> tuple[list[Prediction], list[dict[str, object]]]:
+    """Run bibtex-check and return predictions plus its raw JSONL records."""
+    global _last_source_condition, _ran_bibtex_check
     _last_source_condition = None
+    _ran_bibtex_check = False
     start_time = time.time()
+    raw_records: list[dict[str, object]] = []
 
     # Use a directory we control to avoid cleanup race on timeout
     tmpdir = tempfile.mkdtemp()
@@ -815,8 +879,17 @@ def _run_bibtex_check_subprocess(
         bib_path.write_text(bib_content)
 
         # Build command with performance optimizations
-        binary = resolve_bibtex_check_bin() or "bibtex-check"
+        binary = resolve_bibtex_check_bin()
+        pinned_binary = os.environ.get(BIBTEX_CHECK_BIN_ENV)
+        if pinned_binary and binary is None:
+            raise RuntimeError(
+                f"{BIBTEX_CHECK_BIN_ENV} points at a missing bibtex-check binary: "
+                f"{os.path.expanduser(pinned_binary)}"
+            )
+        binary = binary or "bibtex-check"
         rate_limit = resolve_bibtex_check_rate_limit(rate_limit)
+        mailto = os.environ.get(BIBTEX_CHECK_MAILTO_ENV, "").strip()
+        mailto_domain = mailto.rpartition("@")[2] or None
         # Say which build is answering. Without this the run is silent about the
         # single fact that decides whether its numbers are comparable to any
         # other run's, and PATH may be resolving an editable install.
@@ -828,7 +901,12 @@ def _run_bibtex_check_subprocess(
             if os.environ.get(BIBTEX_CHECK_BIN_ENV)
             else f" [unpinned; set {BIBTEX_CHECK_BIN_ENV} to pin]",
         )
-        logger.info("bibtex-check rate limit: %d req/min per service", rate_limit)
+        logger.info(
+            "bibtex-check pace: --rate-limit %d (scale %d/45; "
+            "the tool derives per-service budgets)",
+            rate_limit,
+            rate_limit,
+        )
         cmd = [
             binary,
             str(bib_path),
@@ -836,6 +914,10 @@ def _run_bibtex_check_subprocess(
             str(jsonl_path),
             "--rate-limit",
             str(rate_limit),
+            "--outage-threshold",
+            str(SOURCE_OUTAGE_THRESHOLD),
+            "--workers",
+            str(BIBTEX_CHECK_WORKERS),
         ]
         if academic_only:
             cmd.append("--academic-only")
@@ -843,11 +925,17 @@ def _run_bibtex_check_subprocess(
         s2_key = os.environ.get("S2_API_KEY")
         if s2_key:
             cmd.extend(["--s2-api-key", s2_key])
+        if mailto:
+            cmd.extend(["--mailto", mailto])
         if extra_args:
             cmd.extend(extra_args)
 
-        # Run bibtex-check (the API key is masked — see redact_command)
-        logger.info(f"Running: {redact_command(cmd)}")
+        # Run bibtex-check. API keys are masked by ``redact_command``; mailto is
+        # masked here because the shared secret-flag table is outside this package.
+        logged_cmd = list(cmd)
+        if mailto:
+            logged_cmd[logged_cmd.index("--mailto") + 1] = "***"
+        logger.info("Running: %s", redact_command(logged_cmd))
         timed_out = False
         try:
             result = subprocess.run(
@@ -856,41 +944,84 @@ def _run_bibtex_check_subprocess(
                 text=True,
                 timeout=timeout,
             )
-            condition = parse_source_condition(result.stdout + result.stderr)
+            _ran_bibtex_check = True
+            if jsonl_path.exists():
+                raw_records = list(parse_jsonl_to_raw(jsonl_path).values())
+            parsed_condition = parse_source_condition(result.stdout + result.stderr)
+            if (
+                parsed_condition is not None
+                and raw_records
+                and any("sources_failed" in record for record in raw_records)
+            ):
+                per_source_failures: dict[str, int] = {}
+                for record in raw_records:
+                    sources_failed = record.get("sources_failed")
+                    if isinstance(sources_failed, list):
+                        for source in sources_failed:
+                            if isinstance(source, str):
+                                per_source_failures[source] = per_source_failures.get(source, 0) + 1
+                parsed_condition["per_source_failures"] = per_source_failures
+            condition = {
+                **(parsed_condition or {}),
+                "rate_limit": rate_limit,
+                "workers": BIBTEX_CHECK_WORKERS,
+                "mailto_configured": bool(mailto),
+                "mailto_domain": mailto_domain,
+            }
             _last_source_condition = condition
-            if result.returncode == EXIT_SOURCE_OUTAGE:
+            if result.returncode == 0 and result.stderr.strip():
+                logger.warning("bibtex-check stderr: %s", result.stderr.strip())
+            if result.returncode == EXIT_SOURCE_OUTAGE and parsed_condition is None:
+                logger.error(
+                    "bibtex-check exited %d for a source outage, but its "
+                    "source-condition report could not be parsed",
+                    EXIT_SOURCE_OUTAGE,
+                )
+            raw_fraction = parsed_condition.get("incomplete_fraction") if parsed_condition else None
+            incomplete_fraction = (
+                float(raw_fraction) if isinstance(raw_fraction, (int, float)) else 0.0
+            )
+            # bibtex-check prints its source report below the threshold too, so
+            # the report's presence proves nothing; the fraction it carries does.
+            # A strict-mode exit 4 is an outage exactly when that fraction says so.
+            is_source_outage = (
+                result.returncode == EXIT_SOURCE_OUTAGE
+                or incomplete_fraction >= SOURCE_OUTAGE_THRESHOLD
+            )
+            if is_source_outage:
                 detail = ""
-                if condition:
+                if parsed_condition:
                     detail = (
-                        f" {condition['entries_with_incomplete_lookups']} of "
-                        f"{condition['entries_total']} entries "
-                        f"({condition['incomplete_fraction']:.1%}) had an incomplete "
-                        f"lookup: {condition['per_source_failures']}."
+                        f" {parsed_condition['entries_with_incomplete_lookups']} of "
+                        f"{parsed_condition['entries_total']} entries "
+                        f"({parsed_condition['incomplete_fraction']:.1%}) had an incomplete "
+                        f"lookup: {parsed_condition['per_source_failures']}."
                     )
                 if os.environ.get(ALLOW_OUTAGE_ENV) == "1":
                     logger.error(
                         "bibtex-check reported a SOURCE OUTAGE (exit %d).%s "
                         "Scoring it anyway because %s=1 -- these numbers are NOT "
                         "comparable to a healthy run.",
-                        EXIT_SOURCE_OUTAGE,
+                        result.returncode,
                         detail,
                         ALLOW_OUTAGE_ENV,
                     )
                 else:
                     raise SourceOutageError(
                         f"bibtex-check reported a source outage (exit "
-                        f"{EXIT_SOURCE_OUTAGE}) and asked for the run to be "
+                        f"{result.returncode}) and asked for the run to be "
                         f"discarded.{detail} A source that never answered is not "
                         "evidence a reference is absent, so this run cannot be "
                         "scored. Re-run when the sources are reachable, or set "
                         f"{ALLOW_OUTAGE_ENV}=1 to score it regardless."
                     )
-            elif result.returncode not in (0, 2, 4):
+            elif result.returncode not in (0, 4):
                 logger.error(f"bibtex-check failed (exit {result.returncode}): {result.stderr}")
         except FileNotFoundError:
             logger.error("bibtex-check not found. Install with: pipx install bibtex-updater")
-            return fallback_predictions(entries, reason="Fallback: bibtex-check unavailable")
+            return fallback_predictions(entries, reason="Fallback: bibtex-check unavailable"), []
         except subprocess.TimeoutExpired:
+            _ran_bibtex_check = True
             timed_out = True
 
         elapsed = time.time() - start_time
@@ -898,6 +1029,13 @@ def _run_bibtex_check_subprocess(
         # Parse JSONL output (works for both complete and partial results)
         predictions: list[Prediction] = []
         if jsonl_path.exists():
+            if not raw_records:
+                raw_records = list(parse_jsonl_to_raw(jsonl_path).values())
+            if raw_records and not any("unconfirmed_fields" in record for record in raw_records):
+                logger.warning(
+                    "bibtex-check JSONL records do not carry unconfirmed_fields; "
+                    "the installed build predates that output capability"
+                )
             predictions = _parse_jsonl_output(jsonl_path, elapsed, len(entries))
 
         checked = len(predictions)
@@ -917,7 +1055,7 @@ def _run_bibtex_check_subprocess(
 
         shutil.rmtree(tmpdir, ignore_errors=True)
 
-    return predictions
+    return predictions, raw_records
 
 
 def parse_jsonl_to_raw(jsonl_path: Path) -> dict[str, dict]:
@@ -967,6 +1105,18 @@ def _parse_jsonl_output(
 
             key = record.get("key", "")
             status = record.get("status", "skipped")
+            is_unmapped = status not in STATUS_TO_LABEL
+            if is_unmapped:
+                if status not in _WARNED_UNMAPPED_STATUSES:
+                    _WARNED_UNMAPPED_STATUSES.add(status)
+                    logger.warning(
+                        "bibtex-check returned unmapped status %r (first seen on %s); "
+                        "emitting UNCERTAIN",
+                        status,
+                        key,
+                    )
+                else:
+                    logger.debug("bibtex-check returned unmapped status %r for %s", status, key)
             raw_confidence = record.get("confidence", STATUS_TO_CONFIDENCE.get(status, 0.5))
             mismatched = record.get("mismatched_fields") or []
             # >= 1.11.0 only; absent on older releases, where abstained fields
@@ -1008,7 +1158,9 @@ def _parse_jsonl_output(
             # rather than counting as committed VALID, so the DR/FPR/F1 triple
             # becomes the selective one. Set HALLMARK_BTU_ABSTENTION_AS_VALID=1
             # to reproduce a published row under the old convention.
-            is_abstention = effective_status in ABSTENTION_STATUSES or incomplete_not_found
+            is_abstention = (
+                effective_status in ABSTENTION_STATUSES or incomplete_not_found or is_unmapped
+            )
             if is_abstention and not abstentions_are_committed_valid():
                 label = "UNCERTAIN"
 
@@ -1043,7 +1195,9 @@ def _parse_jsonl_output(
                 if incomplete_not_found:
                     cause = ABSTENTION_REASONS["coverage_incomplete"]
                 else:
-                    cause = ABSTENTION_REASONS.get(status, "no source answered")
+                    cause = ABSTENTION_REASONS.get(
+                        status, "bibtex-check returned an unmapped status"
+                    )
                 reason_parts.append(
                     f"Abstention: {cause}, so this is not a verdict"
                     + ("" if label == "UNCERTAIN" else " (scored as committed VALID)")

--- a/hallmark/baselines/cascade.py
+++ b/hallmark/baselines/cascade.py
@@ -55,6 +55,8 @@ STATUS_TO_TYPE: dict[str, str] = {
     "author_mismatch": "swapped_authors",
     "year_mismatch": "hybrid_fabrication",
     "title_mismatch": "chimeric_title",
+    # ``_detect_chimeric_title`` is the sole emitter (fact_checker.py:2888).
+    "hallucinated": "chimeric_title",
     "preprint_only": "preprint_as_published",
     "url_not_found": "fabricated_doi",
     "url_content_mismatch": "near_miss_title",
@@ -103,6 +105,7 @@ ROUTE_TO_STAGE2: set[str] = {
     "unconfirmed",
     "strict_warn_preprint_year",
     "strict_warn_cnv",
+    "parse_error",
 }
 
 

--- a/tests/test_abstention_is_not_a_verdict.py
+++ b/tests/test_abstention_is_not_a_verdict.py
@@ -53,7 +53,7 @@ def test_every_abstention_status_maps_to_valid_in_the_legacy_table():
     and one of them is wrong.
     """
     for status in ABSTENTION_STATUSES:
-        assert STATUS_TO_LABEL.get(status) == "VALID", (
+        assert status not in STATUS_TO_LABEL or STATUS_TO_LABEL[status] == "VALID", (
             f"{status!r} is registered as an abstention but STATUS_TO_LABEL maps it to "
             f"{STATUS_TO_LABEL.get(status)!r}. An abstention is a VALID that carries no "
             "evidence; a status mapping elsewhere is a verdict and does not belong here."
@@ -114,11 +114,18 @@ def test_source_outage_abstention_is_uncertain(tmp_path):
     )
 
 
+def test_parse_error_is_uncertain_and_names_the_parse_failure(tmp_path):
+    preds = _preds(tmp_path, [{"key": "a", "status": "parse_error", "p_valid": 0.5}])
+    assert preds["a"].label == "UNCERTAIN"
+    assert "could not read this entry" in preds["a"].reason
+
+
 def test_legacy_env_reproduces_the_published_mapping(tmp_path, monkeypatch):
     """The escape hatch exists to reproduce a published row, not to bless it."""
     records = [
         {"key": "a", "status": "unconfirmed", "abstained": True, "p_valid": 0.22},
         {"key": "b", "status": "not_found", "coverage_incomplete": True},
+        {"key": "c", "status": "future_unmapped_status"},
     ]
     monkeypatch.setenv(ABSTENTION_AS_VALID_ENV, "1")
     assert set(_labels(tmp_path, records).values()) == {"VALID"}

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -67,6 +67,18 @@ class TestStatusMaps:
         routed = set(STATUS_TO_TYPE) | STAGE1_VERIFIED | ROUTE_TO_STAGE2
         assert set(STATUS_TO_LABEL) <= routed
 
+    def test_every_status_the_tool_can_emit_has_a_cascade_route(self) -> None:
+        """The invariant above reads HALLMARK's copy of the vocabulary, so it
+        cannot see a status the tool added and the wrapper never learned.
+
+        bibtex-updater needs bibtexparser 1.x and is installed in isolation, so
+        it is importable only where someone put it in this environment
+        deliberately; the check skips elsewhere.
+        """
+        fact_checker = pytest.importorskip("bibtex_updater.fact_checker")
+        routed = set(STATUS_TO_TYPE) | STAGE1_VERIFIED | ROUTE_TO_STAGE2
+        assert {status.value for status in fact_checker.FactCheckStatus} <= routed
+
 
 class TestBibtexCheckVersion:
     @staticmethod

--- a/tests/test_bibtexupdater.py
+++ b/tests/test_bibtexupdater.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import pytest
 
+from hallmark.baselines import bibtexupdater as btu
 from hallmark.baselines.bibtexupdater import (
     MIN_BATCH_FOR_HEALTH_CHECK,
     NOT_FOUND_SHARE_THRESHOLD,
@@ -36,6 +37,7 @@ from hallmark.baselines.bibtexupdater import (
     run_bibtex_check_with_health,
     run_bibtex_check_with_status,
 )
+from hallmark.baselines.cascade import ROUTE_TO_STAGE2, STAGE1_VERIFIED, STATUS_TO_TYPE
 from hallmark.dataset.schema import BlindEntry, Prediction
 
 
@@ -59,7 +61,73 @@ class TestStatusMaps:
         assert STATUS_TO_LABEL["preprint_only"] == "HALLUCINATED"
 
     def test_every_label_status_has_a_confidence(self) -> None:
-        assert set(STATUS_TO_LABEL) == set(STATUS_TO_CONFIDENCE)
+        assert set(STATUS_TO_LABEL) <= set(STATUS_TO_CONFIDENCE)
+
+    def test_every_bibtex_check_status_has_a_cascade_route(self) -> None:
+        routed = set(STATUS_TO_TYPE) | STAGE1_VERIFIED | ROUTE_TO_STAGE2
+        assert set(STATUS_TO_LABEL) <= routed
+
+
+class TestBibtexCheckVersion:
+    @staticmethod
+    def _version_result(cmd: list[str]) -> Any:
+        return btu.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="1.2.3\n1.2.3\n/fake/bibtex_updater/__init__.py\n",
+            stderr="",
+        )
+
+    def test_uses_the_console_scripts_shebang_interpreter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        interpreter = tmp_path / "venv" / "bin" / "python"
+        interpreter.parent.mkdir(parents=True)
+        interpreter.touch()
+        binary = tmp_path / "bibtex-check"
+        binary.write_text(f"#!{interpreter}\n")
+
+        def _run(cmd: list[str], **_kw: Any) -> Any:
+            assert cmd[0] == str(interpreter)
+            return self._version_result(cmd)
+
+        monkeypatch.setattr(btu.subprocess, "run", _run)
+        assert btu.bibtex_check_version(str(binary)) == "1.2.3"
+
+    def test_resolves_a_symlink_before_using_a_sibling_interpreter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target_dir = tmp_path / "venv" / "bin"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "bibtex-check"
+        target.write_text("# no shebang\n")
+        interpreter = target_dir / "python"
+        interpreter.touch()
+        shim_dir = tmp_path / "shims"
+        shim_dir.mkdir()
+        shim = shim_dir / "bibtex-check"
+        shim.symlink_to(target)
+
+        def _run(cmd: list[str], **_kw: Any) -> Any:
+            assert cmd[0] == str(interpreter)
+            return self._version_result(cmd)
+
+        monkeypatch.setattr(btu.subprocess, "run", _run)
+        assert btu.bibtex_check_version(str(shim)) == "1.2.3"
+
+    def test_warns_when_no_interpreter_can_be_found(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        binary = tmp_path / "bibtex-check"
+        binary.write_text("# no shebang\n")
+
+        with caplog.at_level(logging.WARNING, logger="hallmark.baselines.bibtexupdater"):
+            version = btu.bibtex_check_version(str(binary))
+
+        assert version is None
+        assert any(str(binary) in record.message for record in caplog.records)
 
 
 class TestParseJsonlOutput:
@@ -323,8 +391,8 @@ class TestTransportStatusMapping:
         assert STATUS_TO_LABEL["network_error"] == "VALID"
         assert STATUS_TO_CONFIDENCE["network_error"] == 0.30
 
-    def test_coverage_incomplete_status_is_a_conservative_valid(self) -> None:
-        assert STATUS_TO_LABEL["coverage_incomplete"] == "VALID"
+    def test_coverage_incomplete_status_is_a_forward_compatible_abstention(self) -> None:
+        assert "coverage_incomplete" not in STATUS_TO_LABEL
         assert STATUS_TO_CONFIDENCE["coverage_incomplete"] == 0.45
 
     def test_network_error_record_never_parses_to_hallucinated(self, tmp_path: Path) -> None:
@@ -345,22 +413,33 @@ class TestTransportStatusMapping:
         assert pred.label == "UNCERTAIN"
         assert pred.label != "HALLUCINATED"
 
-    def test_unknown_future_status_never_parses_to_hallucinated(self, tmp_path: Path) -> None:
+    def test_unknown_future_status_is_uncertain_and_warns_once(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """Whatever the sibling tool names its new transport status, an unmapped
-        status falls through to conservative VALID rather than a fabrication
-        verdict."""
+        status abstains rather than becoming a verdict."""
+        status = "transport_failure_some_future_name"
+        monkeypatch.setattr(btu, "_WARNED_UNMAPPED_STATUSES", set(), raising=False)
         records: list[dict[str, Any]] = [
             {
-                "key": "u",
-                "status": "transport_failure_some_future_name",
+                "key": key,
+                "status": status,
                 "confidence": 0.0,
                 "mismatched_fields": [],
                 "api_sources": [],
                 "errors": ["dns failure"],
             }
+            for key in ("u1", "u2")
         ]
-        (pred,) = _parse(tmp_path, records)
-        assert pred.label == "VALID"
+        with caplog.at_level(logging.WARNING, logger="hallmark.baselines.bibtexupdater"):
+            preds = _parse(tmp_path, records)
+
+        assert {pred.label for pred in preds} == {"UNCERTAIN"}
+        warnings = [record for record in caplog.records if status in record.message]
+        assert len(warnings) == 1
 
 
 class TestAssessBatchHealth:
@@ -391,6 +470,20 @@ class TestAssessBatchHealth:
         health = assess_batch_health(["coverage_incomplete"] * 100)
         assert health.suspected_transport_failure
         assert health.coverage_incomplete == 100
+
+    def test_record_flags_count_coverage_and_deduplicate_not_found(self) -> None:
+        try:
+            health = assess_batch_health(
+                ["not_found"] * 40 + ["verified"] * 60,
+                coverage_flags=[True] * 40 + [False] * 60,
+            )
+        except TypeError:
+            health = None
+
+        assert health is not None
+        assert health.not_found == 0
+        assert health.coverage_incomplete == 40
+        assert health.no_evidence == 40
 
     def test_mixed_failure_shapes_accumulate(self) -> None:
         """A partially-upgraded pipeline splits the same outage across statuses;
@@ -447,8 +540,10 @@ def _blind(key: str) -> BlindEntry:
 
 
 def _fake_subprocess(status: str) -> Any:
-    def _run(entries: list[BlindEntry], **_kw: Any) -> list[Prediction]:
-        return [
+    def _run(
+        entries: list[BlindEntry], **_kw: Any
+    ) -> tuple[list[Prediction], list[dict[str, object]]]:
+        predictions = [
             Prediction(
                 bibtex_key=e.bibtex_key,
                 label=STATUS_TO_LABEL.get(status, "VALID"),  # type: ignore[arg-type]
@@ -457,6 +552,10 @@ def _fake_subprocess(status: str) -> Any:
             )
             for e in entries
         ]
+        records: list[dict[str, object]] = [
+            {"key": entry.bibtex_key, "status": status} for entry in entries
+        ]
+        return predictions, records
 
     return _run
 
@@ -515,3 +614,32 @@ class TestBatchHealthPlumbing:
         entries = [_blind(f"k{i}") for i in range(40)]
         _, _, health = run_bibtex_check_with_health(entries, skip_prescreening=True)
         assert not health.suspected_transport_failure
+
+
+@pytest.mark.parametrize(
+    "runner_name",
+    ["run_bibtex_check", "run_bibtex_check_with_status", "run_bibtex_check_with_health"],
+)
+@pytest.mark.parametrize("skip_prescreening", [False, True])
+def test_each_public_runner_invokes_bibtex_check_once(
+    monkeypatch: pytest.MonkeyPatch,
+    runner_name: str,
+    skip_prescreening: bool,
+) -> None:
+    calls = 0
+
+    def _counted(
+        entries: list[BlindEntry], **_kw: Any
+    ) -> tuple[list[Prediction], list[dict[str, object]]]:
+        nonlocal calls
+        calls += 1
+        return _fake_subprocess("verified")(entries)
+
+    monkeypatch.setattr(btu, "_run_bibtex_check_subprocess", _counted)
+    getattr(btu, runner_name)([_blind("one")], skip_prescreening=skip_prescreening)
+
+    assert calls == 1
+
+
+def test_ran_bibtex_check_accessor_is_exposed() -> None:
+    assert callable(getattr(btu, "ran_bibtex_check", None))

--- a/tests/test_source_outage_is_not_scored.py
+++ b/tests/test_source_outage_is_not_scored.py
@@ -21,19 +21,23 @@ in one day, which is why the fix records the condition rather than only refusing
 
 from __future__ import annotations
 
+import json
 import subprocess
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
 from hallmark.baselines import registry as R
 from hallmark.baselines.bibtexupdater import (
     ALLOW_OUTAGE_ENV,
+    BIBTEX_CHECK_BIN_ENV,
     EXIT_SOURCE_OUTAGE,
     SourceOutageError,
     last_source_condition,
     parse_source_condition,
     run_bibtex_check,
+    run_bibtex_check_with_health,
 )
 from hallmark.dataset.schema import BenchmarkEntry, BlindEntry, EvaluationResult
 
@@ -87,9 +91,30 @@ class TestSourceConditionParsing:
         assert cond["per_source_failures"] == {"openalex": 3}
 
 
-def test_the_exit_code_is_the_one_the_tool_documents():
-    """Pinned because the whole guard keys on it."""
-    assert EXIT_SOURCE_OUTAGE == 5
+def test_the_exit_code_matches_the_pinned_tool():
+    """Read the contract from the build the wrapper would actually run."""
+    from hallmark.baselines import bibtexupdater as btu
+
+    binary = btu.resolve_bibtex_check_bin()
+    if binary is None:
+        pytest.skip("bibtex-check is not installed")
+    with open(Path(binary).resolve()) as script:
+        first_line = script.readline().strip()
+    if not first_line.startswith("#!"):
+        pytest.skip("bibtex-check console script has no shebang")
+    interpreter = first_line.removeprefix("#!").strip().split()[0]
+    probe = subprocess.run(
+        [
+            interpreter,
+            "-c",
+            "from bibtex_updater.fact_checker import EXIT_SOURCE_OUTAGE; print(EXIT_SOURCE_OUTAGE)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert int(probe.stdout.strip()) == EXIT_SOURCE_OUTAGE
 
 
 # --- Through the subprocess, not only the regex -----------------------------------
@@ -111,11 +136,23 @@ def fake_bibtex_check(monkeypatch):
     monkeypatch.setattr(btu, "bibtex_check_version", lambda binary=None: "1.2.0")
     monkeypatch.delenv(ALLOW_OUTAGE_ENV, raising=False)
 
-    def _install(returncode: int, output: str):
+    def _install(
+        returncode: int,
+        output: str,
+        records: list[dict] | None = None,
+        stderr: str = "",
+    ):
+        calls: list[list[str]] = []
+
         def _run(cmd, **kw):
-            return subprocess.CompletedProcess(cmd, returncode, stdout=output, stderr="")
+            calls.append(cmd)
+            if records is not None:
+                jsonl_path = Path(cmd[cmd.index("--jsonl") + 1])
+                jsonl_path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+            return subprocess.CompletedProcess(cmd, returncode, stdout=output, stderr=stderr)
 
         monkeypatch.setattr(btu.subprocess, "run", _run)
+        return calls
 
     return _install
 
@@ -123,6 +160,63 @@ def fake_bibtex_check(monkeypatch):
 def test_exit_5_raises_through_the_public_runner(fake_bibtex_check):
     fake_bibtex_check(EXIT_SOURCE_OUTAGE, REAL_OUTAGE_OUTPUT)
     with pytest.raises(SourceOutageError, match="285 of 1119"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_strict_exit_4_with_an_outage_report_is_refused(fake_bibtex_check):
+    fake_bibtex_check(4, REAL_OUTAGE_OUTPUT)
+    with pytest.raises(SourceOutageError, match="285 of 1119"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_strict_exit_4_below_the_threshold_is_not_an_outage(fake_bibtex_check):
+    """bibtex-check prints its source report under the threshold as well, so a
+    strict-mode exit 4 beside an 8% report is a strict verdict, not an outage."""
+    fake_bibtex_check(
+        4,
+        "WARNING: 4 of 50 entries (8.0%) had at least one source lookup that did not "
+        "complete: dblp (4).\n",
+    )
+    run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_threshold_fraction_is_refused_even_when_exit_is_zero(fake_bibtex_check):
+    fake_bibtex_check(
+        0,
+        "WARNING: 5 of 50 entries (10.0%) had at least one source lookup that did not "
+        "complete: dblp (5).\n",
+    )
+    with pytest.raises(SourceOutageError, match="5 of 50"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_wrapper_passes_its_outage_threshold_explicitly(fake_bibtex_check):
+    calls = fake_bibtex_check(0, "INFO: done\n")
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    (cmd,) = calls
+    threshold_index = cmd.index("--outage-threshold")
+    assert float(cmd[threshold_index + 1]) == pytest.approx(0.10)
+
+
+def test_exit_5_without_a_source_report_logs_a_broken_parser(fake_bibtex_check, caplog):
+    fake_bibtex_check(EXIT_SOURCE_OUTAGE, "ERROR: source outage\n")
+    with (
+        caplog.at_level("ERROR", logger="hallmark.baselines.bibtexupdater"),
+        pytest.raises(SourceOutageError),
+    ):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+    assert any("source-condition report" in record.message for record in caplog.records)
+
+
+def test_a_missing_pinned_binary_never_falls_back_to_path(tmp_path, monkeypatch):
+    missing = tmp_path / "missing" / "bibtex-check"
+    monkeypatch.setenv(BIBTEX_CHECK_BIN_ENV, str(missing))
+
+    def _must_not_run(*_args, **_kwargs):
+        raise AssertionError("subprocess.run must not be called for a missing pinned binary")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_run)
+    with pytest.raises(RuntimeError, match=f"{BIBTEX_CHECK_BIN_ENV}.*{missing}"):
         run_bibtex_check(_entries(), skip_prescreening=True)
 
 
@@ -140,18 +234,112 @@ def test_a_sub_threshold_outage_is_recorded_even_though_the_tool_exits_0(fake_bi
     """bibtex-check prints the same summary below its 10% threshold and exits 0."""
     fake_bibtex_check(
         0,
-        "WARNING: 5 of 50 entries (10.0%) had at least one source lookup that did not "
-        "complete: dblp (5). Those entries report api_error, not not_found.\n",
+        "WARNING: 4 of 50 entries (8.0%) had at least one source lookup that did not "
+        "complete: dblp (4). Those entries report api_error, not not_found.\n",
     )
     run_bibtex_check(_entries(), skip_prescreening=True)
     cond = last_source_condition()
-    assert cond is not None and cond["entries_with_incomplete_lookups"] == 5
+    assert cond is not None and cond["entries_with_incomplete_lookups"] == 4
 
 
-def test_a_healthy_run_clears_the_condition(fake_bibtex_check):
+def test_per_source_failures_come_from_jsonl_records(fake_bibtex_check):
+    records = [
+        {"key": "e0", "status": "api_error", "sources_failed": ["dblp", "openalex"]},
+        {"key": "e1", "status": "api_error", "sources_failed": ["dblp"]},
+        {"key": "e2", "status": "verified", "sources_failed": []},
+    ]
+    fake_bibtex_check(
+        0,
+        "WARNING: 2 of 50 entries (4.0%) had at least one source lookup that did not "
+        "complete: stale-log-value (99).\n",
+        records,
+    )
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    cond = last_source_condition()
+    assert cond is not None
+    assert cond["per_source_failures"] == {"dblp": 2, "openalex": 1}
+
+
+def test_record_coverage_flags_reach_batch_health(fake_bibtex_check):
+    records = [
+        {
+            "key": f"e{i}",
+            "status": "unconfirmed" if i < 20 else "verified",
+            "coverage_incomplete": i < 20,
+        }
+        for i in range(40)
+    ]
+    fake_bibtex_check(0, "INFO: done\n", records)
+    _, _, health = run_bibtex_check_with_health(_entries(40), skip_prescreening=True)
+    assert health.coverage_incomplete == 20
+    assert health.no_evidence == 20
+    assert health.suspected_transport_failure
+
+
+def test_a_healthy_run_records_its_pace_and_contact_condition(fake_bibtex_check):
     fake_bibtex_check(0, "INFO: Loaded 3 entries\nINFO: done\n")
     run_bibtex_check(_entries(), skip_prescreening=True)
-    assert last_source_condition() is None
+    assert last_source_condition() == {
+        "rate_limit": 120,
+        "workers": 8,
+        "mailto_configured": False,
+        "mailto_domain": None,
+    }
+
+
+def test_command_and_condition_record_configured_pace_and_contact(
+    fake_bibtex_check, monkeypatch, caplog
+):
+    mailto = "researcher@example.org"
+    monkeypatch.setenv("BIBTEX_CHECK_MAILTO", mailto)
+    calls = fake_bibtex_check(0, "INFO: done\n")
+    with caplog.at_level("INFO", logger="hallmark.baselines.bibtexupdater"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+    (cmd,) = calls
+    assert cmd[cmd.index("--rate-limit") + 1] == "120"
+    assert cmd[cmd.index("--workers") + 1] == "8"
+    assert cmd[cmd.index("--mailto") + 1] == mailto
+    assert last_source_condition() == {
+        "rate_limit": 120,
+        "workers": 8,
+        "mailto_configured": True,
+        "mailto_domain": "example.org",
+    }
+    assert "scale 120/45" in caplog.text
+    assert mailto not in caplog.text
+
+
+def test_clean_exit_stderr_is_not_discarded(fake_bibtex_check, caplog):
+    warning = "No contact email configured; using placeholder"
+    fake_bibtex_check(0, "INFO: done\n", stderr=f"WARNING: {warning}\n")
+    with caplog.at_level("WARNING", logger="hallmark.baselines.bibtexupdater"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+    assert warning in caplog.text
+
+
+def test_exit_2_is_logged_but_partial_jsonl_is_retained(fake_bibtex_check, caplog):
+    records = [{"key": "e0", "status": "verified", "unconfirmed_fields": []}]
+    fake_bibtex_check(2, "", records, stderr="parse failure")
+    with caplog.at_level("ERROR", logger="hallmark.baselines.bibtexupdater"):
+        preds = run_bibtex_check(_entries(), skip_prescreening=True)
+    assert any(pred.bibtex_key == "e0" and pred.reason == "Status: verified" for pred in preds)
+    assert "exit 2" in caplog.text
+
+
+def test_unconfirmed_fields_capability_is_checked_per_run(fake_bibtex_check, caplog):
+    legacy = [{"key": "e0", "status": "verified"}]
+    fake_bibtex_check(0, "", legacy)
+    with caplog.at_level("WARNING", logger="hallmark.baselines.bibtexupdater"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+    assert "unconfirmed_fields" in caplog.text
+
+    caplog.clear()
+    modern = [{"key": "e0", "status": "verified", "unconfirmed_fields": []}]
+    fake_bibtex_check(0, "", modern)
+    with caplog.at_level("WARNING", logger="hallmark.baselines.bibtexupdater"):
+        run_bibtex_check(_entries(), skip_prescreening=True)
+    assert "unconfirmed_fields" not in caplog.text
 
 
 def test_the_condition_lands_on_the_result(fake_bibtex_check, monkeypatch):

--- a/tests/test_source_outage_is_not_scored.py
+++ b/tests/test_source_outage_is_not_scored.py
@@ -61,9 +61,21 @@ class TestSourceConditionParsing:
         assert cond == {
             "entries_with_incomplete_lookups": 285,
             "entries_total": 1119,
-            "incomplete_fraction": pytest.approx(0.255),
+            "incomplete_fraction": pytest.approx(285 / 1119),
+            "reported_fraction": pytest.approx(0.255),
             "per_source_failures": {"dblp": 275, "openalex": 26},
         }
+
+    def test_the_fraction_comes_from_the_counts_not_the_printed_percentage(self):
+        """83 of 831 prints as "10.0%" and is 0.0999, which the tool passes."""
+        cond = parse_source_condition(
+            "WARNING: 83 of 831 entries (10.0%) had at least one source lookup "
+            "that did not complete: dblp (83)"
+        )
+        assert cond is not None
+        assert cond["incomplete_fraction"] == pytest.approx(83 / 831)
+        assert cond["incomplete_fraction"] < 0.10
+        assert cond["reported_fraction"] == pytest.approx(0.10)
 
     def test_a_healthy_run_reports_no_condition(self):
         assert parse_source_condition("INFO: Loaded 1119 entries\nINFO: done") is None
@@ -134,7 +146,12 @@ def fake_bibtex_check(monkeypatch):
 
     monkeypatch.setattr(btu, "resolve_bibtex_check_bin", lambda: "/fake/bibtex-check")
     monkeypatch.setattr(btu, "bibtex_check_version", lambda binary=None: "1.2.0")
+    # Every setting these tests assert over is readable from the environment,
+    # so start each one from a known environment rather than the developer's.
     monkeypatch.delenv(ALLOW_OUTAGE_ENV, raising=False)
+    monkeypatch.delenv(btu.BIBTEX_CHECK_RATE_ENV, raising=False)
+    monkeypatch.delenv(btu.BIBTEX_CHECK_MAILTO_ENV, raising=False)
+    monkeypatch.delenv("S2_API_KEY", raising=False)
 
     def _install(
         returncode: int,
@@ -188,6 +205,49 @@ def test_threshold_fraction_is_refused_even_when_exit_is_zero(fake_bibtex_check)
     )
     with pytest.raises(SourceOutageError, match="5 of 50"):
         run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+@pytest.mark.parametrize(
+    ("summary", "refused"),
+    [
+        # 83/831 = 0.0999: under the threshold, so bibtex-check exits 0 and the
+        # run is scorable. Its own log line rounds that to "10.0%".
+        ("83 of 831 entries (10.0%)", False),
+        # One entry further and the exact fraction is over the threshold.
+        ("84 of 831 entries (10.1%)", True),
+        # Exactly at the threshold, which the gate refuses.
+        ("5 of 50 entries (10.0%)", True),
+    ],
+)
+def test_the_gate_reads_the_counts_not_the_printed_percentage(fake_bibtex_check, summary, refused):
+    """bibtex-check prints a rounded percentage and gates on the exact one.
+
+    Reading the printed number back throws away a completed multi-hour run that
+    the tool itself passed as healthy.
+    """
+    fake_bibtex_check(
+        0,
+        f"WARNING: {summary} had at least one source lookup that did not complete: dblp (1).\n",
+    )
+    if refused:
+        with pytest.raises(SourceOutageError):
+            run_bibtex_check(_entries(), skip_prescreening=True)
+    else:
+        run_bibtex_check(_entries(), skip_prescreening=True)
+
+
+def test_the_condition_records_the_exact_fraction(fake_bibtex_check):
+    """The stamped provenance carries the fraction the gate used."""
+    fake_bibtex_check(
+        0,
+        "WARNING: 83 of 831 entries (10.0%) had at least one source lookup that did not "
+        "complete: dblp (83).\n",
+    )
+    run_bibtex_check(_entries(), skip_prescreening=True)
+    cond = last_source_condition()
+    assert cond is not None
+    assert cond["incomplete_fraction"] == pytest.approx(83 / 831)
+    assert cond["reported_fraction"] == pytest.approx(0.10)
 
 
 def test_wrapper_passes_its_outage_threshold_explicitly(fake_bibtex_check):
@@ -308,6 +368,48 @@ def test_command_and_condition_record_configured_pace_and_contact(
     }
     assert "scale 120/45" in caplog.text
     assert mailto not in caplog.text
+
+
+@pytest.mark.parametrize("spelling", ["separate", "joined"])
+def test_a_contact_address_passed_through_extra_args_is_masked(fake_bibtex_check, caplog, spelling):
+    """The address can arrive on the command line without the wrapper putting it
+    there, and argparse accepts both spellings."""
+    address = "leak@lab.example"
+    extra_args = ["--mailto", address] if spelling == "separate" else [f"--mailto={address}"]
+    fake_bibtex_check(0, "INFO: done\n")
+    with caplog.at_level("INFO", logger="hallmark.baselines.bibtexupdater"):
+        run_bibtex_check(_entries(), skip_prescreening=True, extra_args=extra_args)
+    assert address not in caplog.text
+    assert "***" in caplog.text
+
+
+def test_the_condition_records_the_settings_the_command_ran_with(fake_bibtex_check):
+    """argparse takes the last occurrence, so extra_args beat the wrapper's own
+    flags and the stamp has to follow the command rather than the constants."""
+    calls = fake_bibtex_check(0, "INFO: done\n")
+    run_bibtex_check(_entries(), skip_prescreening=True, extra_args=["--workers", "2"])
+    (cmd,) = calls
+    assert cmd[cmd.index("--workers") + 1] == "8", "the wrapper still sets its own default"
+    assert cmd[-2:] == ["--workers", "2"], "and the caller's override comes after it"
+    assert last_source_condition() == {
+        "rate_limit": 120,
+        "workers": 2,
+        "mailto_configured": False,
+        "mailto_domain": None,
+    }
+
+
+def test_a_contact_address_from_extra_args_reaches_the_condition(fake_bibtex_check):
+    fake_bibtex_check(0, "INFO: done\n")
+    run_bibtex_check(
+        _entries(),
+        skip_prescreening=True,
+        extra_args=["--mailto=researcher@lab.example"],
+    )
+    cond = last_source_condition()
+    assert cond is not None
+    assert cond["mailto_configured"] is True
+    assert cond["mailto_domain"] == "lab.example"
 
 
 def test_clean_exit_stderr_is_not_discarded(fake_bibtex_check, caplog):


### PR DESCRIPTION
Wrapper-integrity package from the 2026-09-06 review: findings X1-1 (CRITICAL), X1-2, X1-3, X1-4, X1-6, X1-7, X1-9, X1-10, X1-11 and H2-1, H2-2, H2-3, H2-4, H2-6, H2-8, H2-11, H2-16, each reproduced by a verifier. Decisions taken: DEC-4 (an outage wins over a strict-mode exit), DEC-12 (an unmapped status is UNCERTAIN), DEC-13 in part (record the run condition; defaults unchanged).

## What was wrong

- **The tool ran twice per evaluation.** `run_bibtex_check_with_status` ran the subprocess over the whole split, then handed `run_with_prescreening` a callable that ran it again, and compared run 1's labels with run 2's to decide which entries were pre-screening overrides. Every published bibtex-updater row cost double the API calls and compared two runs' answers.
- **`parse_error` was a committed VALID**, and so was any status the wrapper had never seen (`STATUS_TO_LABEL.get(status, "VALID")`). The cascade had no route for `hallucinated`, the tool's chimeric-title verdict.
- **`tool_version` was None on every pipx install**: the version probe looked for `python` beside the `~/.local/bin` symlink rather than the resolved script.
- **The pin did not pin**: an unresolvable `HALLMARK_BIBTEX_CHECK_BIN` logged an error and fell back to PATH, the editable-install failure the variable exists to prevent.
- **An outage under `--strict` was scored**: bibtex-check's exit 4 preempts exit 5, and the wrapper recognised an outage on exit 5 alone.
- **The run condition was unrecorded and mislabelled**: `--rate-limit` was logged as "req/min per service" although it is a scale factor over per-service budgets; no `--mailto` (so CrossRef's public pool), no explicit `--workers`, none of it on `source_condition`.

## What changes

One subprocess run per call; `ran_bibtex_check()` reports whether the tool actually started, for the provenance stamp (HM-D and HM-F consume it). `parse_error` is an abstention; an unmapped status is emitted as UNCERTAIN with one warning per status (`HALLMARK_BTU_ABSTENTION_AS_VALID=1` stays as the reproduction escape hatch). `hallucinated` → `chimeric_title`; `parse_error` routes to Stage 2. The version probe reads the resolved script's shebang. A missing pinned binary raises. The wrapper passes `--outage-threshold 0.10` and refuses the run whenever the tool's own report says the incomplete-lookup fraction is at or above it, under any exit code; a report *below* the threshold beside exit 4 stays a strict verdict (the tool prints the report below the threshold too, so its presence proves nothing). `--workers` is passed at the tool's default, `--mailto` from `BIBTEX_CHECK_MAILTO` when set (masked in the log), and rate / workers / contact-configured (domain only) are recorded on `source_condition`. `assess_batch_health` reads the raw `coverage_incomplete` flags. Partial JSONL survives an unexpected exit; clean-exit stderr is surfaced; a JSONL without `unconfirmed_fields` warns that the build predates that output.

**Defaults do not change** (rate 120, workers 8, no mailto unless the environment sets one); whether they should is DEC-13 and is raised separately. **Deferred:** the unreachable `strict_warn_cnv` origin branch (DEC-11) and `api_calls` counting sources-with-hits rather than calls (DEC-5).

## Verification

Full suite 1478 passed / 17 skipped; ruff, ruff-format, mypy clean via pre-commit. New tests: invocation count and accessor; `parse_error` and unmapped-status handling with the escape hatch; cascade vocabulary; shebang, symlink and missing-interpreter version probes; missing pinned binary raises at the public runner; exit 5, exit 4 above threshold, exit 0 at threshold refused, exit 4 below threshold accepted; command-line contents. Diff produced by codex from the review specification; the exit-4 rule narrowed by hand and read line by line before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
