### PR TITLE
Four passages say what the artifacts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,17 @@ changing position — and moves six tools under as-false-positives (tau 0.968 an
 0.965), so the instability belongs to the four modes rather than to folding a
 mode class,
 though at 4.3% and 5.6% of positives that null carries less weight than the
-effect it contrasts with. And the cascade's 1.000 is not an artefact of how the
-entries were generated: a gradient-boosted classifier over surface features
-alone, with no lookup of any kind, reaches detection rate 0.468 on `dev_public`
-and 0.388 on `test_public` against false-positive rates of 0.045 and 0.096. Some
-separability is there, and it is far short of what the cascade achieves.
+effect it contrasts with.
+
+Surface features alone — field presence, string lengths, author count, entry
+type, year, no lookups — separate the four modes from VALID entries at DR 0.468
+on `dev_public` and 0.388 on `test_public` against a majority baseline of 0.000,
+and conditioning the negatives the same way the positives are conditioned does
+not move it. That is real leakage and a benchmark limitation. It is also well
+short of the cascade's 1.000, so the cascade's score is not only the generator
+being read back.
+
+Reproduce: `uv run --with scikit-learn python scripts/shortcut_control_four_modes.py`
 
 `stress_test` inherits the same property by construction. It holds three modes,
 two of which are on this list: 75 of its 121 scored entries, 62%. Its one VALID
@@ -587,8 +593,8 @@ wrong. **The gap between "this work does not exist" and "this entry describes a
 real work incorrectly" carries most of the real signal**, and the current
 taxonomy folds the second into the first (see
 [issue #36](https://github.com/rpatrik96/hallmark/issues/36)); on the wild
-corpus, 63% of flags were real works described wrongly, 47% from venue and
-preprint status alone.
+corpus, of the 324 references Stage 2 upheld as flags, 59.0% resolved to a real
+work described wrongly.
 
 This analysis is joint work with the InterpScience submission-screening effort,
 which contributed the 5,043-reference corpus and its adjudications.

--- a/hf/README.md
+++ b/hf/README.md
@@ -40,8 +40,6 @@ configs:
 
 > This is the staged card for a future HuggingFace publication. No HuggingFace mirror is live.
 
-> **Anonymized for NeurIPS 2026 Datasets & Benchmarks Track double-blind review.**
-> Source code: <https://anonymous.4open.science/r/hallmark/>
 > **Corpus version:** v1.2.3 (2026-08-31) — see the source repository's `CHANGELOG.md` and tagged releases for provenance of every version.
 
 **HALL**ucination bench**MARK** evaluates citation verification tools on detecting hallucinated references in academic papers. The benchmark was motivated by the NeurIPS 2025 incident in which 53 accepted papers were found to contain fabricated citations that passed peer review.

--- a/notes/eval-hardening-2026-09-04.md
+++ b/notes/eval-hardening-2026-09-04.md
@@ -180,9 +180,9 @@ refused the run — the guard working exactly as designed.
 Three causes, all fixed: the keyless OpenAlex pool (1,000/day/IP) was exhausted
 and returned 429 to a bare probe; OpenReview 403s without credentials; and the
 wrapper drove `--rate-limit 120` where the tool's documented baseline is 45.
-With a key, credentials and a rate of 20, failures fell to **10.0%** — and the run
-got **faster**, 2.4 s/entry against 5.7, because pacing avoids the retry storms
-that retrying causes. Pacing beats retrying, with the clock going the right way.
+With a key, credentials and a rate of 20, failures fell to **25.5%** — 285 of the
+same 1,119 entries — because pacing avoids the retry storms that retrying causes.
+Pacing beats retrying.
 
 Two things worth carrying: **a dead credential is worse than none** (the expired
 S2 key 403'd every call while keyless merely throttled — dropping it took failures
@@ -343,7 +343,7 @@ paper as a stated result rather than being settled by relabelling five splits.
   counts.
 - **Issue #36**, the largest open item: the taxonomy folds "this work does not
   exist" together with "this entry describes a real work incorrectly". On the
-  wild corpus 63% of flags were the second kind, 47% from venue and preprint
-  status alone.
+  wild corpus, of the 324 references Stage 2 upheld as flags, 59.0% resolved to a real
+work described wrongly.
 - **Regenerating the reference results** under pinned versions, and rebuilding
   the README and site from one run.

--- a/notes/source-availability-is-a-measurement-condition.md
+++ b/notes/source-availability-is-a-measurement-condition.md
@@ -47,9 +47,9 @@ attribute a source outage to pre-screening.
 Two independent measurements say the effect is large enough to change a
 conclusion. Correcting the source conditions on the same tool and split —
 supplying the keys, the credentials and a 20-per-minute pace — moved the
-incomplete-lookup fraction from 53.7% to 10.0%, and the run got *faster*: 2.4
-seconds per entry against 5.7. Pacing beats retrying, because a starved source
-turns into a retry storm that costs more than the wait it was avoiding. And on a
+incomplete-lookup fraction from 53.7% to 25.5%, 285 of 1,119 entries in the
+16:00 attempt above. Pacing beats retrying, because a starved source turns into
+a retry storm that costs more than the wait it was avoiding. And on a
 119-entry probe holding the model and prompt fixed, 12% of flags cleared with
 arXiv starved against 24% with it answering: the same verifier, the same
 entries, half the corrections.


### PR DESCRIPTION
The four prose passages Patrik ruled on at the end of the 2026-09-06 review (decisions DEC-19, DEC-20, DEC-21, DEC-D). Left open for him to read the exact texts before merging.

1. **"53.7% to 10.0%"** (`notes/eval-hardening-2026-09-04.md`, `notes/source-availability-is-a-measurement-condition.md`). The 10.0% came from a 60-entry probe that itself exited 5; the 53.7% from a 1,119-entry run. Both notes now give the like-for-like full-split figure, 285 of 1,119 (25.5%), the 16:00 attempt in the second note's own table. The 2.4 vs 5.7 s/entry pair is dropped: no committed file records it. "Pacing beats retrying" stays.
2. **"63% of flags … 47% from venue and preprint status alone"** (README, and the same sentence in the outcomes note). Recomputed over `interpscience-bib-check/screening/predictions_stage2_remapped.jsonl`: 191 of the 324 references Stage 2 upheld as flags carry `remap_class == METADATA_MISMATCH`, 59.0%. The sentence states that denominator; the 47% clause, which appears in no artifact, is removed. Caveat carried: `remap_class` is a regex classification of the verifier's stated reason, not a hand adjudication, and the sentence claims no more.
3. **Shortcut control** (README). The paragraph now leads with the leakage the note reports: surface features alone reach DR 0.468 / 0.388 against a 0.000 majority baseline, conditioning the negatives the same way moves nothing, that is real leakage and a benchmark limitation, and it is well short of the cascade's 1.000. Reproduce line added; the script was re-run and gives 0.468 / FPR 0.045 and 0.388 / FPR 0.096.
4. **hf/README.md**: the "Anonymized for NeurIPS 2026 double-blind review" banner and the anonymous.4open.science link are removed; the staged-card header stays. `croissant.json` is untouched (its anonymity fields stay by the 2026-09-05 ruling).

The planning note `notes/eval-hardening-plan-2026-09.md` still carries the 63% / 47% wording; it is marked superseded and kept as a record of what was believed that morning, so it is left as is.

Verification: `tests/test_data_integrity.py tests/test_table_freshness.py` 46 passed; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
